### PR TITLE
2.0 No longer requires nightscout / herokuapp

### DIFF
--- a/App.config
+++ b/App.config
@@ -5,6 +5,7 @@
     </startup>
   <appSettings>
     <add key="NightscoutUrl" value="https://accountname.herokuapp.com"/>
+    <add key="ApiSecret" value=""/> <!-- Leave blank unless you need to pass an ApiSecret -->
     <add key="HighBg" value="180"/>
     <add key="DangerHighBg" value="250"/>
     <add key="LowBg" value="80"/>

--- a/App.config
+++ b/App.config
@@ -4,8 +4,9 @@
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
     </startup>
   <appSettings>
-    <add key="NightscoutUrl" value="https://accountname.herokuapp.com"/>
-    <add key="ApiSecret" value=""/> <!-- Leave blank unless you need to pass an ApiSecret -->
+    <add key="NightscoutUrl" value="https://accountname.herokuapp.com"/> <!-- Optional, enter here to use right-click shortcut to site. -->
+    <add key="DexcomUsername" value="username"/>
+    <add key="DexcomPassword" value="password"/>
     <add key="HighBg" value="180"/>
     <add key="DangerHighBg" value="250"/>
     <add key="LowBg" value="80"/>

--- a/AppContext.cs
+++ b/AppContext.cs
@@ -22,16 +22,16 @@ namespace GlucoseTray
             // Initialize Tray Icon
             trayIcon = new NotifyIcon()
             {
-                ContextMenu = new ContextMenu(new MenuItem[] 
-                {
-                    new MenuItem("Nightscout", (obj,e) => Process.Start(Constants.NightscoutUrl)),
-                    new MenuItem("Exit", new EventHandler(Exit))
-                }),
+                ContextMenu = new ContextMenu(new MenuItem[]{}),
                 Visible = true
             };
 
+            if(!string.IsNullOrWhiteSpace(Constants.NightscoutUrl))
+                trayIcon.ContextMenu.MenuItems.Add(new MenuItem("Nightscout", (obj, e) => Process.Start(Constants.NightscoutUrl)));
+            trayIcon.ContextMenu.MenuItems.Add(new MenuItem("Exit", new EventHandler(Exit)));
+
             trayIcon.DoubleClick += ShowBalloon;
-            
+
             while (true)
             {
                 try

--- a/Constants.cs
+++ b/Constants.cs
@@ -5,7 +5,8 @@ namespace GlucoseTray
     public static class Constants
     {
         public static string NightscoutUrl => ConfigurationManager.AppSettings["NightscoutUrl"];
-        public static string ApiSecret => ConfigurationManager.AppSettings["ApiSecret"];
+        public static string DexcomUsername => ConfigurationManager.AppSettings["DexcomUsername"];
+        public static string DexcomPassword => ConfigurationManager.AppSettings["DexcomPassword"];
         public static int HighBg => int.Parse(ConfigurationManager.AppSettings["HighBg"]);
         public static int DangerHighBg => int.Parse(ConfigurationManager.AppSettings["DangerHighBg"]);
         public static int LowBg => int.Parse(ConfigurationManager.AppSettings["LowBg"]);

--- a/Constants.cs
+++ b/Constants.cs
@@ -5,6 +5,7 @@ namespace GlucoseTray
     public static class Constants
     {
         public static string NightscoutUrl => ConfigurationManager.AppSettings["NightscoutUrl"];
+        public static string ApiSecret => ConfigurationManager.AppSettings["ApiSecret"];
         public static int HighBg => int.Parse(ConfigurationManager.AppSettings["HighBg"]);
         public static int DangerHighBg => int.Parse(ConfigurationManager.AppSettings["DangerHighBg"]);
         public static int LowBg => int.Parse(ConfigurationManager.AppSettings["LowBg"]);

--- a/GlucoseTray.sln
+++ b/GlucoseTray.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 16.0.28803.202
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GlucoseTray", "GlucoseTray.csproj", "{342CE19D-D0D0-49C7-9E55-6585289A8DDC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GlucoseTray.Tests", "..\GlucoseTray.Tests\GlucoseTray.Tests.csproj", "{BCE2E69E-5634-47A8-B492-7EC93D8F4D21}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{342CE19D-D0D0-49C7-9E55-6585289A8DDC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{342CE19D-D0D0-49C7-9E55-6585289A8DDC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{342CE19D-D0D0-49C7-9E55-6585289A8DDC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BCE2E69E-5634-47A8-B492-7EC93D8F4D21}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BCE2E69E-5634-47A8-B492-7EC93D8F4D21}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BCE2E69E-5634-47A8-B492-7EC93D8F4D21}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BCE2E69E-5634-47A8-B492-7EC93D8F4D21}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Models/GlucoseFetchResult.cs
+++ b/Models/GlucoseFetchResult.cs
@@ -5,7 +5,6 @@ namespace GlucoseTray.Models
     public class GlucoseFetchResult
     {
         public int Value { get; set; }
-        public string Trend { get; set; }
         public string TrendIcon { get; set; }
         public DateTime Time { get; set; }
     }

--- a/Services/GlucoseFetchService.cs
+++ b/Services/GlucoseFetchService.cs
@@ -1,38 +1,65 @@
 ﻿using System;
 using System.Net.Http;
-using System.Text.RegularExpressions;
+using System.Text;
 using GlucoseTray.Models;
 
 namespace GlucoseTray.Services
 {
     public class GlucoseFetchService
     {
-        private readonly string _request = Constants.NightscoutUrl + "/api/v1/entries/sgv?count=1";
+        private readonly string baseUrl = "https://share1.dexcom.com";
 
         public GlucoseFetchResult GetLatestReading()
         {
             var client = new HttpClient();
-            HttpResponseMessage response = new HttpResponseMessage();
+            var request = new HttpRequestMessage();
+            var response = new HttpResponseMessage();
 
             try
             {
-                if(!string.IsNullOrWhiteSpace(Constants.ApiSecret))
-                    client.DefaultRequestHeaders.Add("api_secret", Constants.ApiSecret);
-                response = client.GetAsync(_request).Result;
-                var content = response.Content.ReadAsStringAsync().Result.Split('\t');
+                // Get Session Id
+                request.RequestUri = new Uri($"{baseUrl}/ShareWebServices/Services/General/LoginPublisherAccountByName");
+                request.Method = HttpMethod.Post;
+                request.Content = new StringContent("{\"accountName\":\"" + Constants.DexcomUsername + "\"," +
+                                                     "\"applicationId\":\"d8665ade-9673-4e27-9ff6-92db4ce13d13\"," +
+                                                     "\"password\":\"" + Constants.DexcomPassword + "\"}", Encoding.UTF8, "application/json");
+                response = client.SendAsync(request).Result;
+                var sessionId = response.Content.ReadAsStringAsync().Result.Replace("\"", "");
 
-                Regex rgx = new Regex("[^a-zA-Z]");
-                var time = ParseDate(content[0]);
+                request = new HttpRequestMessage
+                {
+                    RequestUri = new Uri($"{baseUrl}/ShareWebServices/Services/Publisher/ReadPublisherLatestGlucoseValues?sessionId={sessionId}&minutes=1440&maxCount=1"),
+                    Method = HttpMethod.Post
+                };
+                var result = client.SendAsync(request).Result.Content.ReadAsStringAsync().Result
+                                                                                                .Replace("[", "")
+                                                                                                .Replace("]", "")
+                                                                                                .Replace("\\", "")
+                                                                                                .Replace("/", "")
+                                                                                                .Replace("\"", "")
+                                                                                                .Replace("{", "")
+                                                                                                .Replace("}", "")
+                                                                                                .Replace("(", "")
+                                                                                                .Replace(")", "")
+                                                                                                .Split(',');
 
-                var trendString = rgx.Replace(content[3], "");
-                var val = int.Parse(content[2]);
+                // Get raw data seperated
+                var unixTime = result[1].Split('e')[1];
+                var trend = result[2].Split(':')[1];
+                var stringVal = result[3].Split(':')[1];
+
+                // Convert raw to correct data
+                DateTime localTime = DateTime.MinValue;
+                if (!string.IsNullOrWhiteSpace(unixTime))
+                    localTime = DateTimeOffset.FromUnixTimeMilliseconds(long.Parse(unixTime)).LocalDateTime;
+                int.TryParse(stringVal, out int val);
+                var trendIcon = GetTrendArrow(trend);
 
                 return new GlucoseFetchResult()
                 {
                     Value = val,
-                    Trend = trendString,
-                    Time = time,
-                    TrendIcon = GetTrendArrow(trendString)
+                    Time = localTime,
+                    TrendIcon = trendIcon
                 };
             }
             catch (Exception e)
@@ -42,53 +69,33 @@ namespace GlucoseTray.Services
                 return new GlucoseFetchResult()
                 {
                     Value = 0,
-                    Trend = "Flat",
                     Time = DateTime.Now,
-                    TrendIcon = GetTrendArrow("Flat")
+                    TrendIcon = GetTrendArrow("4")
                 };
             }
             finally
             {
                 client.Dispose();
                 response.Dispose();
+                request.Dispose();
             }
-        }
-
-        private DateTime ParseDate(string date)
-        {
-            Regex rgx = new Regex("[^0-9]");
-
-            var ymd = date.Split('T')[0].Split('-');
-            var hms = date.Split('T')[1].Split('.')[0].Split(':');
-
-            var year = int.Parse(rgx.Replace(ymd[0], ""));
-            var month = int.Parse(rgx.Replace(ymd[1], ""));
-            var day = int.Parse(rgx.Replace(ymd[2], ""));
-
-            var hour = int.Parse(rgx.Replace(hms[0], ""));
-            var minute = int.Parse(rgx.Replace(hms[1], ""));
-            var second = int.Parse(rgx.Replace(hms[2], ""));
-
-            var dateTime = new DateTime(year, month, day, hour, minute, second, DateTimeKind.Utc);
-
-            return dateTime.ToLocalTime();
         }
 
         private string GetTrendArrow(string trend)
         {
-            if (string.Equals(trend, "Flat", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(trend, "4", StringComparison.OrdinalIgnoreCase))
                 return "→";
-            else if (string.Equals(trend, "FortyFiveDown", StringComparison.OrdinalIgnoreCase))
+            else if (string.Equals(trend, "5", StringComparison.OrdinalIgnoreCase))
                 return "↘";
-            else if (string.Equals(trend, "FortyFiveUp", StringComparison.OrdinalIgnoreCase))
+            else if (string.Equals(trend, "3", StringComparison.OrdinalIgnoreCase))
                 return "↗";
-            else if (string.Equals(trend, "SingleDown", StringComparison.OrdinalIgnoreCase))
+            else if (string.Equals(trend, "6", StringComparison.OrdinalIgnoreCase))
                 return "↓";
-            else if (string.Equals(trend, "SingleUp", StringComparison.OrdinalIgnoreCase))
+            else if (string.Equals(trend, "2", StringComparison.OrdinalIgnoreCase))
                 return "↑";
-            else if (string.Equals(trend, "DoubleDown", StringComparison.OrdinalIgnoreCase))
+            else if (string.Equals(trend, "7", StringComparison.OrdinalIgnoreCase))
                 return "⮇";
-            else if (string.Equals(trend, "DoubleUp", StringComparison.OrdinalIgnoreCase))
+            else if (string.Equals(trend, "1", StringComparison.OrdinalIgnoreCase))
                 return "⮅";
             else
                 return "";

--- a/Services/GlucoseFetchService.cs
+++ b/Services/GlucoseFetchService.cs
@@ -16,6 +16,8 @@ namespace GlucoseTray.Services
 
             try
             {
+                if(!string.IsNullOrWhiteSpace(Constants.ApiSecret))
+                    client.DefaultRequestHeaders.Add("api_secret", Constants.ApiSecret);
                 response = client.GetAsync(_request).Result;
                 var content = response.Content.ReadAsStringAsync().Result.Split('\t');
 


### PR DESCRIPTION
No longer requires Nightscout to be setup or installed.  Grabs data the same way Nightscout does, directly from Dexcom.