### PR TITLE
Moving manifest signing to release build only

### DIFF
--- a/GlucoseTray/GlucoseTray.csproj
+++ b/GlucoseTray/GlucoseTray.csproj
@@ -48,17 +48,10 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup>
+
     <ManifestCertificateThumbprint>7F97390D21695D0325D50D2E48820EFB38D328E0</ManifestCertificateThumbprint>
-  </PropertyGroup>
-  <PropertyGroup>
     <ManifestKeyFile>GlucoseTray_TemporaryKey.pfx</ManifestKeyFile>
-  </PropertyGroup>
-  <PropertyGroup>
     <GenerateManifests>true</GenerateManifests>
-  </PropertyGroup>
-  <PropertyGroup>
     <SignManifests>true</SignManifests>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
I don't have a cert for signing it installed. This eases development.