### PR TITLE
Add ability to choose international servers for Dexcom Share

### DIFF
--- a/Dexcom.Fetch/Enums/DexcomServer.cs
+++ b/Dexcom.Fetch/Enums/DexcomServer.cs
@@ -1,0 +1,9 @@
+﻿namespace Dexcom.Fetch.Enums
+{
+    public enum DexcomServerLocation
+    {
+        DexcomShare1 = 0,
+        DexcomShare2 = 1,
+        DexcomInternational = 2,
+    }
+}

--- a/Dexcom.Fetch/Models/GlucoseFetchConfiguration.cs
+++ b/Dexcom.Fetch/Models/GlucoseFetchConfiguration.cs
@@ -33,6 +33,8 @@ namespace Dexcom.Fetch.Models
         /// </summary>
         public string DexcomPassword { get; set; }
 
+        public DexcomServerLocation DexcomServer { get; set; }
+
         /// <summary>
         /// MG/DL or MMOL/L
         /// </summary>

--- a/GlucoseTrayCore/AppContext.cs
+++ b/GlucoseTrayCore/AppContext.cs
@@ -82,6 +82,7 @@ namespace GlucoseTrayCore
             IsCriticalLow = false;
             var service = new GlucoseFetchService(new GlucoseFetchConfiguration
             {
+                DexcomServer = Constants.DexcomServer,
                 DexcomUsername = Constants.DexcomUsername,
                 DexcomPassword = Constants.DexcomPassword,
                 FetchMethod = Constants.FetchMethod,

--- a/GlucoseTrayCore/Constants.cs
+++ b/GlucoseTrayCore/Constants.cs
@@ -13,6 +13,7 @@ namespace GlucoseTrayCore
 
         public static FetchMethod FetchMethod => (FetchMethod)Convert.ToInt32(AppSettings["FetchMethod"]);
         public static string NightscoutUrl => AppSettings["NightscoutUrl"];
+        public static DexcomServerLocation DexcomServer => (DexcomServerLocation)Convert.ToInt32(AppSettings["DexcomServer"]);
         public static string DexcomUsername => AppSettings["DexcomUsername"];
         public static string DexcomPassword => AppSettings["DexcomPassword"];
         public static string AccessToken => AppSettings["AccessToken"];

--- a/GlucoseTrayCore/appsettings.json
+++ b/GlucoseTrayCore/appsettings.json
@@ -8,6 +8,10 @@
     "DexcomUsername": "",
     "DexcomPassword": "",
 
+    // Dexcom server
+    // 0 for default (US, share1), 1 for alt (US, share2) or 2 for non-US (shareous1, outside US)
+    "DexcomServer": "0",
+
     // Nightscout Auth
     // If using AUTH_DEFAULT_ROLES = denied in Nightscout configuration, create an access key with at least 'readable' role and enter the token here. Otherwise, leave blank.
     "AccessToken": "",


### PR DESCRIPTION
Added a new config file variable called `DexcomServer` that allows the user to configure which Dexcom Share API server is used during calls.

As a user from South Africa I couldn't get the app to work and I had to change the URI to the international one. I decided to contribute this back.