### PR TITLE
Pr strikeout

### DIFF
--- a/Dexcom.Fetch/Extensions/GlucoseFetchResultExtensions.cs
+++ b/Dexcom.Fetch/Extensions/GlucoseFetchResultExtensions.cs
@@ -11,5 +11,19 @@ namespace Dexcom.Fetch.Extensions
                 value = fetchResult.Value.ToString("0.0");
             return value;
         }
+
+        public static bool IsStale(this GlucoseFetchResult fetchResult, int minutes)
+        {
+            var ts = System.DateTime.Now - fetchResult.Time;
+
+            return ts.TotalMinutes > minutes;
+        }
+
+        public static string StaleMessage(this GlucoseFetchResult fetchResult, int minutes)
+        {
+            var ts = System.DateTime.Now - fetchResult.Time;
+
+            return ts.TotalMinutes > minutes ? $"\r\n{ts.TotalMinutes:#} minutes ago" : "";
+        }
     }
 }

--- a/GlucoseTrayCore/AppContext.cs
+++ b/GlucoseTrayCore/AppContext.cs
@@ -99,6 +99,6 @@ namespace GlucoseTrayCore
 
         private void ShowBalloon(object sender, EventArgs e) => trayIcon.ShowBalloonTip(2000, "Glucose", GetGlucoseMessage(), ToolTipIcon.Info);
 
-        private string GetGlucoseMessage() => $"{FetchResult.GetFormattedStringValue()}   {FetchResult.Time.ToLongTimeString()}  {FetchResult.TrendIcon}";
+        private string GetGlucoseMessage() => $"{FetchResult.GetFormattedStringValue()}   {FetchResult.Time.ToLongTimeString()}  {FetchResult.TrendIcon}{FetchResult.StaleMessage(Constants.StaleResultsThreshold)}";
     }
 }

--- a/GlucoseTrayCore/Constants.cs
+++ b/GlucoseTrayCore/Constants.cs
@@ -28,6 +28,8 @@ namespace GlucoseTrayCore
         public static bool EnableDebugMode => Convert.ToBoolean(AppSettings["EnableDebugMode"]);
         public static LogEventLevel LogLevel => (LogEventLevel)Convert.ToInt32(AppSettings["LogLevel"]);
 
+        public static int StaleResultsThreshold => Convert.ToInt32(AppSettings["StaleResultsThreshold"] ?? "15");
+
         public static void LogCurrentConfig(ILogger logger)
         {
             logger.LogDebug($"{nameof(FetchMethod)}: {FetchMethod}");
@@ -45,6 +47,7 @@ namespace GlucoseTrayCore
             logger.LogDebug($"{nameof(ErrorLogPath)}: {ErrorLogPath}");
             logger.LogDebug($"{nameof(EnableDebugMode)}: {EnableDebugMode}");
             logger.LogDebug($"{nameof(LogLevel)}: {LogLevel}");
+            logger.LogDebug($"{nameof(StaleResultsThreshold)}: {StaleResultsThreshold}");
         }
     }
 }

--- a/GlucoseTrayCore/Services/IconService.cs
+++ b/GlucoseTrayCore/Services/IconService.cs
@@ -40,6 +40,8 @@ namespace GlucoseTrayCore.Services
         {
             var result = fetchResult.GetFormattedStringValue().Replace('.', '\''); // Use ' instead of . since it is narrower and allows a better display of a two digit number + decimal place.
 
+            var isStale = fetchResult.IsStale(Constants.StaleResultsThreshold);
+
             if (result == "0")
             {
                 _logger.LogWarning("Empty glucose result received.");
@@ -53,7 +55,7 @@ namespace GlucoseTrayCore.Services
 
             var xOffset = CalculateXPosition(fetchResult);
             var fontSize = _useDefaultFontSize ? _defaultFontSize : _smallerFontSize;
-            _fontToUse = new Font("Roboto", fontSize, FontStyle.Regular, GraphicsUnit.Pixel);
+            _fontToUse = new Font("Roboto", fontSize, isStale ? FontStyle.Strikeout : FontStyle.Regular, GraphicsUnit.Pixel);
 
             var bitmapText = new Bitmap(16, 16);
             var g = Graphics.FromImage(bitmapText);

--- a/GlucoseTrayCore/appsettings.json
+++ b/GlucoseTrayCore/appsettings.json
@@ -37,6 +37,9 @@
     "ErrorLogPath": "c:\\TEMP\\TrayError.txt",
     "EnableDebugMode": "false",
     // Verbose = 0, Debug = 1, Information = 2, Warning = 3, Error = 4, Fatal = 5
-    "LogLevel": "1"
+    "LogLevel": "1",
+
+    // Time in minutes before we consider results stale.
+    "StaleResultsThreshold": "15"
   }
 }


### PR DESCRIPTION
Strikes out the results if they become stale, i.e. if the results are older than a configurable length of time (15 minutes by default).
Also amended tooltip to indicate how old the results actually are if they are stale.