### PR TITLE
No more appsettings.json.  UI for changing settings.

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -38,7 +38,7 @@ jobs:
         #artifact: 
         # An optional set of paths representing artifacts to upload to the release. This may be a single path or a comma delimited list of paths (or globs)
         #artifacts: './GlucoseTrayCore/bin/Release/net5.0-windows/win-x64/publish/'
-        artifacts: './GlucoseTrayCore/bin/Release/net5.0-windows/win-x64/publish/appsettings.json,./GlucoseTrayCore/bin/Release/net5.0-windows/win-x64/publish/GlucoseTrayCore.exe'
+        artifacts: './GlucoseTrayCore/bin/Release/net5.0-windows/win-x64/publish/GlucoseTrayCore.exe'
         # The content type of the artifact. Defaults to raw
         #artifactContentType: # optional, default is 
         # An optional body for the release.

--- a/GlucoseTrayCore/AppContext.cs
+++ b/GlucoseTrayCore/AppContext.cs
@@ -148,9 +148,7 @@ namespace GlucoseTrayCore
         {
             using var settings = new Settings();
             if (settings.ShowDialog() == DialogResult.OK)
-            {
-               
-            }
+                MessageBox.Show("Settings saved");
         }
 
         private async Task CreateIcon()

--- a/GlucoseTrayCore/GlucoseTrayCore.csproj
+++ b/GlucoseTrayCore/GlucoseTrayCore.csproj
@@ -17,13 +17,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="appsettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-    </Content>
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />

--- a/GlucoseTrayCore/GlucoseTraySettings.cs
+++ b/GlucoseTrayCore/GlucoseTraySettings.cs
@@ -13,8 +13,8 @@ namespace GlucoseTrayCore
         public string DexcomPassword { get; set; }
         public string AccessToken { get; set; }
         public GlucoseUnitType GlucoseUnit { get; set; }
+        public double WarningHighBg { get; set; }
         public double HighBg { get; set; }
-        public double DangerHighBg { get; set; }
         public double WarningLowBg { get; set; }
         public double LowBg { get; set; }
         public double CriticalLowBg { get; set; }

--- a/GlucoseTrayCore/GlucoseTraySettings.cs
+++ b/GlucoseTrayCore/GlucoseTraySettings.cs
@@ -15,8 +15,8 @@ namespace GlucoseTrayCore
         public GlucoseUnitType GlucoseUnit { get; set; }
         public double HighBg { get; set; }
         public double DangerHighBg { get; set; }
+        public double WarningLowBg { get; set; }
         public double LowBg { get; set; }
-        public double DangerLowBg { get; set; }
         public double CriticalLowBg { get; set; }
         public int PollingThreshold { get; set; }
         public TimeSpan PollingThresholdTimeSpan => TimeSpan.FromSeconds(PollingThreshold);

--- a/GlucoseTrayCore/Program.cs
+++ b/GlucoseTrayCore/Program.cs
@@ -1,5 +1,6 @@
 ﻿using GlucoseTrayCore.Data;
 using GlucoseTrayCore.Services;
+using GlucoseTrayCore.Views;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -19,9 +20,29 @@ namespace GlucoseTrayCore
     internal class Program
     {
         private static IConfigurationSection Configuration { get; set; }
+        private static string SettingsFile { get; set; }
 
         private static void Main(string[] args)
         {
+            SettingsFile = Application.UserAppDataPath + @"\glucose_tray_settings.txt";
+            if (File.Exists(SettingsFile))
+            {
+                LoadSettingsFile();
+            }
+            else
+            {
+                using var settingsWindow = new Settings();
+                if (settingsWindow.ShowDialog() == DialogResult.OK)
+                {
+                    LoadSettingsFile();
+                }
+                else // Did not want to setup application.
+                {
+                    Application.Exit();
+                    return;
+                }
+            }
+
             var host = Host.CreateDefaultBuilder()
                 .ConfigureAppConfiguration((context, builder) => builder.SetBasePath(Directory.GetCurrentDirectory()).AddJsonFile("appsettings.json", optional: false, reloadOnChange: true))
                 .ConfigureServices((context, services) => ConfigureServices(context.Configuration, services))
@@ -66,6 +87,11 @@ namespace GlucoseTrayCore
                     .AddScoped<TaskSchedulerService, TaskSchedulerService>()
                     .AddScoped<IGlucoseFetchService, GlucoseFetchService>()
                     .AddDbContext<IGlucoseTrayDbContext, SQLiteDbContext>(o => o.UseSqlite("Data Source=" + Configuration.GetValue<string>(nameof(GlucoseTraySettings.DatabaseLocation))));
+        }
+
+        private static void LoadSettingsFile()
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/GlucoseTrayCore/Program.cs
+++ b/GlucoseTrayCore/Program.cs
@@ -20,23 +20,15 @@ namespace GlucoseTrayCore
     internal class Program
     {
         private static IConfigurationSection Configuration { get; set; }
-        private static string SettingsFile { get; set; }
+        public static string SettingsFile { get; set; }
 
         private static void Main(string[] args)
         {
-            SettingsFile = Application.UserAppDataPath + @"\glucose_tray_settings.txt";
-            if (File.Exists(SettingsFile))
-            {
-                LoadSettingsFile();
-            }
-            else
+            SettingsFile = Application.UserAppDataPath + @"\glucose_tray_settings.json";
+            if (!File.Exists(SettingsFile))
             {
                 using var settingsWindow = new Settings();
-                if (settingsWindow.ShowDialog() == DialogResult.OK)
-                {
-                    LoadSettingsFile();
-                }
-                else // Did not want to setup application.
+                if (settingsWindow.ShowDialog() != DialogResult.OK) // Did not want to setup application.
                 {
                     Application.Exit();
                     return;
@@ -44,7 +36,7 @@ namespace GlucoseTrayCore
             }
 
             var host = Host.CreateDefaultBuilder()
-                .ConfigureAppConfiguration((context, builder) => builder.SetBasePath(Directory.GetCurrentDirectory()).AddJsonFile("appsettings.json", optional: false, reloadOnChange: true))
+                .ConfigureAppConfiguration((context, builder) => builder.AddJsonFile(SettingsFile, optional: false, reloadOnChange: true))
                 .ConfigureServices((context, services) => ConfigureServices(context.Configuration, services))
                 .ConfigureLogging((context, logging) =>
                 {
@@ -87,11 +79,6 @@ namespace GlucoseTrayCore
                     .AddScoped<TaskSchedulerService, TaskSchedulerService>()
                     .AddScoped<IGlucoseFetchService, GlucoseFetchService>()
                     .AddDbContext<IGlucoseTrayDbContext, SQLiteDbContext>(o => o.UseSqlite("Data Source=" + Configuration.GetValue<string>(nameof(GlucoseTraySettings.DatabaseLocation))));
-        }
-
-        private static void LoadSettingsFile()
-        {
-            throw new NotImplementedException();
         }
     }
 }

--- a/GlucoseTrayCore/Program.cs
+++ b/GlucoseTrayCore/Program.cs
@@ -19,23 +19,21 @@ namespace GlucoseTrayCore
 {
     internal class Program
     {
-        private static IConfigurationSection Configuration { get; set; }
+        private static IConfiguration Configuration { get; set; }
         public static string SettingsFile { get; set; }
 
         private static void Main(string[] args)
         {
             SettingsFile = Application.UserAppDataPath + @"\glucose_tray_settings.json";
-            if (!File.Exists(SettingsFile))
+            using var settingsWindow = new Settings();
+            if (!File.Exists(SettingsFile) || !settingsWindow.ValidateSettings())
             {
-                using var settingsWindow = new Settings();
                 if (settingsWindow.ShowDialog() != DialogResult.OK) // Did not want to setup application.
                 {
                     Application.Exit();
                     return;
                 }
             }
-
-            // TODO: If settings file invalid, re-force settings view
 
             var host = Host.CreateDefaultBuilder()
                 .ConfigureAppConfiguration((context, builder) => builder.AddJsonFile(SettingsFile, optional: false, reloadOnChange: true))
@@ -73,7 +71,7 @@ namespace GlucoseTrayCore
 
         private static void ConfigureServices(IConfiguration configuration, IServiceCollection services)
         {
-            Configuration = configuration.GetSection("appsettings");
+            Configuration = configuration;
             services.Configure<GlucoseTraySettings>(Configuration)
                     .AddHttpClient()
                     .AddScoped<AppContext, AppContext>()

--- a/GlucoseTrayCore/Program.cs
+++ b/GlucoseTrayCore/Program.cs
@@ -35,6 +35,8 @@ namespace GlucoseTrayCore
                 }
             }
 
+            // TODO: If settings file invalid, re-force settings view
+
             var host = Host.CreateDefaultBuilder()
                 .ConfigureAppConfiguration((context, builder) => builder.AddJsonFile(SettingsFile, optional: false, reloadOnChange: true))
                 .ConfigureServices((context, services) => ConfigureServices(context.Configuration, services))

--- a/GlucoseTrayCore/Services/IconService.cs
+++ b/GlucoseTrayCore/Services/IconService.cs
@@ -33,9 +33,9 @@ namespace GlucoseTrayCore.Services
 
         internal Brush SetColor(double val) => val switch
         {
-            double n when n < _options.CurrentValue.HighBg && n > _options.CurrentValue.WarningLowBg => new SolidBrush(Color.White),
-            double n when n >= _options.CurrentValue.HighBg && n < _options.CurrentValue.DangerHighBg => new SolidBrush(Color.Yellow),
-            double n when n >= _options.CurrentValue.DangerHighBg => new SolidBrush(Color.Red),
+            double n when n < _options.CurrentValue.WarningHighBg && n > _options.CurrentValue.WarningLowBg => new SolidBrush(Color.White),
+            double n when n >= _options.CurrentValue.WarningHighBg && n < _options.CurrentValue.HighBg => new SolidBrush(Color.Yellow),
+            double n when n >= _options.CurrentValue.HighBg => new SolidBrush(Color.Red),
             double n when n <= _options.CurrentValue.WarningLowBg && n > _options.CurrentValue.LowBg => new SolidBrush(Color.Yellow),
             double n when n <= _options.CurrentValue.LowBg && n > _options.CurrentValue.CriticalLowBg => new SolidBrush(Color.Red),
             double n when n <= _options.CurrentValue.CriticalLowBg && n > 0 => new SolidBrush(Color.Red),

--- a/GlucoseTrayCore/Views/Settings.Designer.cs
+++ b/GlucoseTrayCore/Views/Settings.Designer.cs
@@ -222,7 +222,7 @@ namespace GlucoseTrayCore.Views
             this.radio_dexcom_server_us_share1.Location = new System.Drawing.Point(184, 75);
             this.radio_dexcom_server_us_share1.Name = "radio_dexcom_server_us_share1";
             this.radio_dexcom_server_us_share1.Size = new System.Drawing.Size(123, 27);
-            this.radio_dexcom_server_us_share1.TabIndex = 5;
+            this.radio_dexcom_server_us_share1.TabIndex = 4;
             this.radio_dexcom_server_us_share1.TabStop = true;
             this.radio_dexcom_server_us_share1.Text = "US Share 1";
             this.radio_dexcom_server_us_share1.UseVisualStyleBackColor = true;
@@ -244,7 +244,7 @@ namespace GlucoseTrayCore.Views
             this.maskedText_dexcom_password.Location = new System.Drawing.Point(184, 31);
             this.maskedText_dexcom_password.Name = "maskedText_dexcom_password";
             this.maskedText_dexcom_password.Size = new System.Drawing.Size(176, 31);
-            this.maskedText_dexcom_password.TabIndex = 7;
+            this.maskedText_dexcom_password.TabIndex = 3;
             this.maskedText_dexcom_password.UseSystemPasswordChar = true;
             // 
             // nightscout_grid
@@ -322,7 +322,7 @@ namespace GlucoseTrayCore.Views
             this.radio_glucose_unit_mmol.Location = new System.Drawing.Point(184, 42);
             this.radio_glucose_unit_mmol.Name = "radio_glucose_unit_mmol";
             this.radio_glucose_unit_mmol.Size = new System.Drawing.Size(110, 33);
-            this.radio_glucose_unit_mmol.TabIndex = 1;
+            this.radio_glucose_unit_mmol.TabIndex = 8;
             this.radio_glucose_unit_mmol.TabStop = true;
             this.radio_glucose_unit_mmol.Text = "MMOG/L";
             this.radio_glucose_unit_mmol.UseVisualStyleBackColor = true;
@@ -345,7 +345,7 @@ namespace GlucoseTrayCore.Views
             this.radio_glucose_unit_mg.Location = new System.Drawing.Point(53, 42);
             this.radio_glucose_unit_mg.Name = "radio_glucose_unit_mg";
             this.radio_glucose_unit_mg.Size = new System.Drawing.Size(93, 33);
-            this.radio_glucose_unit_mg.TabIndex = 2;
+            this.radio_glucose_unit_mg.TabIndex = 7;
             this.radio_glucose_unit_mg.TabStop = true;
             this.radio_glucose_unit_mg.Text = "MG/DL";
             this.radio_glucose_unit_mg.UseVisualStyleBackColor = true;
@@ -445,7 +445,7 @@ namespace GlucoseTrayCore.Views
             0});
             this.numeric_glucose_high.Name = "numeric_glucose_high";
             this.numeric_glucose_high.Size = new System.Drawing.Size(89, 31);
-            this.numeric_glucose_high.TabIndex = 6;
+            this.numeric_glucose_high.TabIndex = 9;
             this.numeric_glucose_high.Value = new decimal(new int[] {
             300,
             0,
@@ -462,7 +462,7 @@ namespace GlucoseTrayCore.Views
             0});
             this.numeric_glucose_warning_high.Name = "numeric_glucose_warning_high";
             this.numeric_glucose_warning_high.Size = new System.Drawing.Size(89, 31);
-            this.numeric_glucose_warning_high.TabIndex = 7;
+            this.numeric_glucose_warning_high.TabIndex = 10;
             this.numeric_glucose_warning_high.Value = new decimal(new int[] {
             250,
             0,
@@ -479,7 +479,7 @@ namespace GlucoseTrayCore.Views
             0});
             this.numeric_glucose_warning_low.Name = "numeric_glucose_warning_low";
             this.numeric_glucose_warning_low.Size = new System.Drawing.Size(89, 31);
-            this.numeric_glucose_warning_low.TabIndex = 8;
+            this.numeric_glucose_warning_low.TabIndex = 11;
             this.numeric_glucose_warning_low.Value = new decimal(new int[] {
             80,
             0,
@@ -496,7 +496,7 @@ namespace GlucoseTrayCore.Views
             0});
             this.numeric_glucose_low.Name = "numeric_glucose_low";
             this.numeric_glucose_low.Size = new System.Drawing.Size(89, 31);
-            this.numeric_glucose_low.TabIndex = 9;
+            this.numeric_glucose_low.TabIndex = 12;
             this.numeric_glucose_low.Value = new decimal(new int[] {
             70,
             0,
@@ -513,7 +513,7 @@ namespace GlucoseTrayCore.Views
             0});
             this.numeric_glucose_critical.Name = "numeric_glucose_critical";
             this.numeric_glucose_critical.Size = new System.Drawing.Size(89, 31);
-            this.numeric_glucose_critical.TabIndex = 10;
+            this.numeric_glucose_critical.TabIndex = 13;
             this.numeric_glucose_critical.Value = new decimal(new int[] {
             55,
             0,
@@ -523,9 +523,9 @@ namespace GlucoseTrayCore.Views
             // tableLayoutPanel1
             // 
             this.tableLayoutPanel1.ColumnCount = 3;
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 51.23457F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 48.76543F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 165F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 58.5443F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 41.4557F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 167F));
             this.tableLayoutPanel1.Controls.Add(this.numeric_polling_threshold, 1, 0);
             this.tableLayoutPanel1.Controls.Add(this.label_polling_threshold, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.label_stale_results, 0, 1);
@@ -544,21 +544,21 @@ namespace GlucoseTrayCore.Views
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(467, 199);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(482, 199);
             this.tableLayoutPanel1.TabIndex = 8;
             // 
             // numeric_polling_threshold
             // 
             this.numeric_polling_threshold.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.numeric_polling_threshold.Location = new System.Drawing.Point(304, 3);
+            this.numeric_polling_threshold.Location = new System.Drawing.Point(317, 3);
             this.numeric_polling_threshold.Maximum = new decimal(new int[] {
             99999,
             0,
             0,
             0});
             this.numeric_polling_threshold.Name = "numeric_polling_threshold";
-            this.numeric_polling_threshold.Size = new System.Drawing.Size(160, 31);
-            this.numeric_polling_threshold.TabIndex = 9;
+            this.numeric_polling_threshold.Size = new System.Drawing.Size(162, 31);
+            this.numeric_polling_threshold.TabIndex = 14;
             this.numeric_polling_threshold.Value = new decimal(new int[] {
             15,
             0,
@@ -581,7 +581,7 @@ namespace GlucoseTrayCore.Views
             this.tableLayoutPanel1.SetColumnSpan(this.label_stale_results, 2);
             this.label_stale_results.Location = new System.Drawing.Point(3, 40);
             this.label_stale_results.Name = "label_stale_results";
-            this.label_stale_results.Size = new System.Drawing.Size(235, 40);
+            this.label_stale_results.Size = new System.Drawing.Size(308, 25);
             this.label_stale_results.TabIndex = 2;
             this.label_stale_results.Text = "Consider Results State After (minutes)";
             // 
@@ -598,10 +598,10 @@ namespace GlucoseTrayCore.Views
             // comboBox_log_level
             // 
             this.comboBox_log_level.FormattingEnabled = true;
-            this.comboBox_log_level.Location = new System.Drawing.Point(304, 83);
+            this.comboBox_log_level.Location = new System.Drawing.Point(317, 83);
             this.comboBox_log_level.Name = "comboBox_log_level";
             this.comboBox_log_level.Size = new System.Drawing.Size(137, 33);
-            this.comboBox_log_level.TabIndex = 5;
+            this.comboBox_log_level.TabIndex = 16;
             // 
             // label_debug_mode
             // 
@@ -616,10 +616,10 @@ namespace GlucoseTrayCore.Views
             // 
             this.checkBox_debug_mode.AutoSize = true;
             this.checkBox_debug_mode.Dock = System.Windows.Forms.DockStyle.Top;
-            this.checkBox_debug_mode.Location = new System.Drawing.Point(157, 123);
+            this.checkBox_debug_mode.Location = new System.Drawing.Point(187, 123);
             this.checkBox_debug_mode.Name = "checkBox_debug_mode";
-            this.checkBox_debug_mode.Size = new System.Drawing.Size(141, 21);
-            this.checkBox_debug_mode.TabIndex = 7;
+            this.checkBox_debug_mode.Size = new System.Drawing.Size(124, 21);
+            this.checkBox_debug_mode.TabIndex = 17;
             this.checkBox_debug_mode.UseVisualStyleBackColor = true;
             // 
             // label_db_location
@@ -627,13 +627,13 @@ namespace GlucoseTrayCore.Views
             this.label_db_location.AutoSize = true;
             this.label_db_location.Location = new System.Drawing.Point(3, 160);
             this.label_db_location.Name = "label_db_location";
-            this.label_db_location.Size = new System.Drawing.Size(91, 40);
+            this.label_db_location.Size = new System.Drawing.Size(158, 25);
             this.label_db_location.TabIndex = 8;
             this.label_db_location.Text = "Database Location";
             // 
             // numeric_stale_results
             // 
-            this.numeric_stale_results.Location = new System.Drawing.Point(304, 43);
+            this.numeric_stale_results.Location = new System.Drawing.Point(317, 43);
             this.numeric_stale_results.Maximum = new decimal(new int[] {
             9999,
             0,
@@ -641,7 +641,7 @@ namespace GlucoseTrayCore.Views
             0});
             this.numeric_stale_results.Name = "numeric_stale_results";
             this.numeric_stale_results.Size = new System.Drawing.Size(137, 31);
-            this.numeric_stale_results.TabIndex = 3;
+            this.numeric_stale_results.TabIndex = 15;
             this.numeric_stale_results.Value = new decimal(new int[] {
             15,
             0,
@@ -652,10 +652,10 @@ namespace GlucoseTrayCore.Views
             // 
             this.tableLayoutPanel1.SetColumnSpan(this.textBox_db_location_result, 2);
             this.textBox_db_location_result.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.textBox_db_location_result.Location = new System.Drawing.Point(157, 163);
+            this.textBox_db_location_result.Location = new System.Drawing.Point(187, 163);
             this.textBox_db_location_result.Name = "textBox_db_location_result";
-            this.textBox_db_location_result.Size = new System.Drawing.Size(307, 31);
-            this.textBox_db_location_result.TabIndex = 10;
+            this.textBox_db_location_result.Size = new System.Drawing.Size(292, 31);
+            this.textBox_db_location_result.TabIndex = 18;
             this.textBox_db_location_result.Text = "C:\\temp\\glucosetray.db";
             // 
             // button_save

--- a/GlucoseTrayCore/Views/Settings.Designer.cs
+++ b/GlucoseTrayCore/Views/Settings.Designer.cs
@@ -525,7 +525,7 @@ namespace GlucoseTrayCore.Views
             this.tableLayoutPanel1.ColumnCount = 3;
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 51.23457F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 48.76543F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 150F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 155F));
             this.tableLayoutPanel1.Controls.Add(this.numeric_polling_threshold, 1, 0);
             this.tableLayoutPanel1.Controls.Add(this.label_polling_threshold, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.label_stale_results, 0, 1);
@@ -550,14 +550,14 @@ namespace GlucoseTrayCore.Views
             // numeric_polling_threshold
             // 
             this.numeric_polling_threshold.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.numeric_polling_threshold.Location = new System.Drawing.Point(319, 3);
+            this.numeric_polling_threshold.Location = new System.Drawing.Point(314, 3);
             this.numeric_polling_threshold.Maximum = new decimal(new int[] {
             99999,
             0,
             0,
             0});
             this.numeric_polling_threshold.Name = "numeric_polling_threshold";
-            this.numeric_polling_threshold.Size = new System.Drawing.Size(145, 31);
+            this.numeric_polling_threshold.Size = new System.Drawing.Size(150, 31);
             this.numeric_polling_threshold.TabIndex = 9;
             this.numeric_polling_threshold.Value = new decimal(new int[] {
             15,
@@ -581,7 +581,7 @@ namespace GlucoseTrayCore.Views
             this.tableLayoutPanel1.SetColumnSpan(this.label_stale_results, 2);
             this.label_stale_results.Location = new System.Drawing.Point(3, 40);
             this.label_stale_results.Name = "label_stale_results";
-            this.label_stale_results.Size = new System.Drawing.Size(308, 25);
+            this.label_stale_results.Size = new System.Drawing.Size(235, 40);
             this.label_stale_results.TabIndex = 2;
             this.label_stale_results.Text = "Consider Results State After (minutes)";
             // 
@@ -598,7 +598,7 @@ namespace GlucoseTrayCore.Views
             // comboBox_log_level
             // 
             this.comboBox_log_level.FormattingEnabled = true;
-            this.comboBox_log_level.Location = new System.Drawing.Point(319, 83);
+            this.comboBox_log_level.Location = new System.Drawing.Point(314, 83);
             this.comboBox_log_level.Name = "comboBox_log_level";
             this.comboBox_log_level.Size = new System.Drawing.Size(137, 33);
             this.comboBox_log_level.TabIndex = 5;
@@ -616,9 +616,9 @@ namespace GlucoseTrayCore.Views
             // 
             this.checkBox_debug_mode.AutoSize = true;
             this.checkBox_debug_mode.Dock = System.Windows.Forms.DockStyle.Top;
-            this.checkBox_debug_mode.Location = new System.Drawing.Point(165, 123);
+            this.checkBox_debug_mode.Location = new System.Drawing.Point(162, 123);
             this.checkBox_debug_mode.Name = "checkBox_debug_mode";
-            this.checkBox_debug_mode.Size = new System.Drawing.Size(148, 21);
+            this.checkBox_debug_mode.Size = new System.Drawing.Size(146, 21);
             this.checkBox_debug_mode.TabIndex = 7;
             this.checkBox_debug_mode.UseVisualStyleBackColor = true;
             // 
@@ -633,7 +633,7 @@ namespace GlucoseTrayCore.Views
             // 
             // numeric_stale_results
             // 
-            this.numeric_stale_results.Location = new System.Drawing.Point(319, 43);
+            this.numeric_stale_results.Location = new System.Drawing.Point(314, 43);
             this.numeric_stale_results.Maximum = new decimal(new int[] {
             9999,
             0,
@@ -652,9 +652,9 @@ namespace GlucoseTrayCore.Views
             // 
             this.tableLayoutPanel1.SetColumnSpan(this.textBox_db_location_result, 2);
             this.textBox_db_location_result.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.textBox_db_location_result.Location = new System.Drawing.Point(165, 163);
+            this.textBox_db_location_result.Location = new System.Drawing.Point(162, 163);
             this.textBox_db_location_result.Name = "textBox_db_location_result";
-            this.textBox_db_location_result.Size = new System.Drawing.Size(299, 31);
+            this.textBox_db_location_result.Size = new System.Drawing.Size(302, 31);
             this.textBox_db_location_result.TabIndex = 10;
             this.textBox_db_location_result.Text = "C:\\temp\\glucosetray.db";
             // 

--- a/GlucoseTrayCore/Views/Settings.Designer.cs
+++ b/GlucoseTrayCore/Views/Settings.Designer.cs
@@ -74,6 +74,7 @@ namespace GlucoseTrayCore.Views
             this.label_db_location = new System.Windows.Forms.Label();
             this.numeric_stale_results = new System.Windows.Forms.NumericUpDown();
             this.textBox_db_location_result = new System.Windows.Forms.TextBox();
+            this.button_save = new System.Windows.Forms.Button();
             this.datasource_grid.SuspendLayout();
             this.dexcom_settings_grid.SuspendLayout();
             this.nightscout_grid.SuspendLayout();
@@ -524,7 +525,7 @@ namespace GlucoseTrayCore.Views
             this.tableLayoutPanel1.ColumnCount = 3;
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 51.23457F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 48.76543F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 144F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 150F));
             this.tableLayoutPanel1.Controls.Add(this.numeric_polling_threshold, 1, 0);
             this.tableLayoutPanel1.Controls.Add(this.label_polling_threshold, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.label_stale_results, 0, 1);
@@ -549,14 +550,14 @@ namespace GlucoseTrayCore.Views
             // numeric_polling_threshold
             // 
             this.numeric_polling_threshold.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.numeric_polling_threshold.Location = new System.Drawing.Point(325, 3);
+            this.numeric_polling_threshold.Location = new System.Drawing.Point(319, 3);
             this.numeric_polling_threshold.Maximum = new decimal(new int[] {
             99999,
             0,
             0,
             0});
             this.numeric_polling_threshold.Name = "numeric_polling_threshold";
-            this.numeric_polling_threshold.Size = new System.Drawing.Size(139, 31);
+            this.numeric_polling_threshold.Size = new System.Drawing.Size(145, 31);
             this.numeric_polling_threshold.TabIndex = 9;
             this.numeric_polling_threshold.Value = new decimal(new int[] {
             15,
@@ -597,7 +598,7 @@ namespace GlucoseTrayCore.Views
             // comboBox_log_level
             // 
             this.comboBox_log_level.FormattingEnabled = true;
-            this.comboBox_log_level.Location = new System.Drawing.Point(325, 83);
+            this.comboBox_log_level.Location = new System.Drawing.Point(319, 83);
             this.comboBox_log_level.Name = "comboBox_log_level";
             this.comboBox_log_level.Size = new System.Drawing.Size(137, 33);
             this.comboBox_log_level.TabIndex = 5;
@@ -615,9 +616,9 @@ namespace GlucoseTrayCore.Views
             // 
             this.checkBox_debug_mode.AutoSize = true;
             this.checkBox_debug_mode.Dock = System.Windows.Forms.DockStyle.Top;
-            this.checkBox_debug_mode.Location = new System.Drawing.Point(168, 123);
+            this.checkBox_debug_mode.Location = new System.Drawing.Point(165, 123);
             this.checkBox_debug_mode.Name = "checkBox_debug_mode";
-            this.checkBox_debug_mode.Size = new System.Drawing.Size(151, 21);
+            this.checkBox_debug_mode.Size = new System.Drawing.Size(148, 21);
             this.checkBox_debug_mode.TabIndex = 7;
             this.checkBox_debug_mode.UseVisualStyleBackColor = true;
             // 
@@ -626,13 +627,13 @@ namespace GlucoseTrayCore.Views
             this.label_db_location.AutoSize = true;
             this.label_db_location.Location = new System.Drawing.Point(3, 160);
             this.label_db_location.Name = "label_db_location";
-            this.label_db_location.Size = new System.Drawing.Size(158, 25);
+            this.label_db_location.Size = new System.Drawing.Size(91, 40);
             this.label_db_location.TabIndex = 8;
             this.label_db_location.Text = "Database Location";
             // 
             // numeric_stale_results
             // 
-            this.numeric_stale_results.Location = new System.Drawing.Point(325, 43);
+            this.numeric_stale_results.Location = new System.Drawing.Point(319, 43);
             this.numeric_stale_results.Maximum = new decimal(new int[] {
             9999,
             0,
@@ -651,17 +652,28 @@ namespace GlucoseTrayCore.Views
             // 
             this.tableLayoutPanel1.SetColumnSpan(this.textBox_db_location_result, 2);
             this.textBox_db_location_result.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.textBox_db_location_result.Location = new System.Drawing.Point(168, 163);
+            this.textBox_db_location_result.Location = new System.Drawing.Point(165, 163);
             this.textBox_db_location_result.Name = "textBox_db_location_result";
-            this.textBox_db_location_result.Size = new System.Drawing.Size(296, 31);
+            this.textBox_db_location_result.Size = new System.Drawing.Size(299, 31);
             this.textBox_db_location_result.TabIndex = 10;
             this.textBox_db_location_result.Text = "C:\\temp\\glucosetray.db";
+            // 
+            // button_save
+            // 
+            this.button_save.Location = new System.Drawing.Point(341, 524);
+            this.button_save.Name = "button_save";
+            this.button_save.Size = new System.Drawing.Size(189, 34);
+            this.button_save.TabIndex = 9;
+            this.button_save.Text = "Save";
+            this.button_save.UseVisualStyleBackColor = true;
+            this.button_save.Click += new System.EventHandler(this.button_save_Click);
             // 
             // Settings
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 25F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(800, 582);
+            this.Controls.Add(this.button_save);
             this.Controls.Add(this.tableLayoutPanel1);
             this.Controls.Add(this.dexcom_settings_grid);
             this.Controls.Add(this.glucose_values_grid);
@@ -740,5 +752,6 @@ namespace GlucoseTrayCore.Views
         private System.Windows.Forms.Label label_db_location;
         private System.Windows.Forms.NumericUpDown numeric_polling_threshold;
         private System.Windows.Forms.TextBox textBox_db_location_result;
+        private System.Windows.Forms.Button button_save;
     }
 }

--- a/GlucoseTrayCore/Views/Settings.Designer.cs
+++ b/GlucoseTrayCore/Views/Settings.Designer.cs
@@ -525,7 +525,7 @@ namespace GlucoseTrayCore.Views
             this.tableLayoutPanel1.ColumnCount = 3;
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 51.23457F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 48.76543F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 155F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 165F));
             this.tableLayoutPanel1.Controls.Add(this.numeric_polling_threshold, 1, 0);
             this.tableLayoutPanel1.Controls.Add(this.label_polling_threshold, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.label_stale_results, 0, 1);
@@ -550,14 +550,14 @@ namespace GlucoseTrayCore.Views
             // numeric_polling_threshold
             // 
             this.numeric_polling_threshold.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.numeric_polling_threshold.Location = new System.Drawing.Point(314, 3);
+            this.numeric_polling_threshold.Location = new System.Drawing.Point(304, 3);
             this.numeric_polling_threshold.Maximum = new decimal(new int[] {
             99999,
             0,
             0,
             0});
             this.numeric_polling_threshold.Name = "numeric_polling_threshold";
-            this.numeric_polling_threshold.Size = new System.Drawing.Size(150, 31);
+            this.numeric_polling_threshold.Size = new System.Drawing.Size(160, 31);
             this.numeric_polling_threshold.TabIndex = 9;
             this.numeric_polling_threshold.Value = new decimal(new int[] {
             15,
@@ -598,7 +598,7 @@ namespace GlucoseTrayCore.Views
             // comboBox_log_level
             // 
             this.comboBox_log_level.FormattingEnabled = true;
-            this.comboBox_log_level.Location = new System.Drawing.Point(314, 83);
+            this.comboBox_log_level.Location = new System.Drawing.Point(304, 83);
             this.comboBox_log_level.Name = "comboBox_log_level";
             this.comboBox_log_level.Size = new System.Drawing.Size(137, 33);
             this.comboBox_log_level.TabIndex = 5;
@@ -616,9 +616,9 @@ namespace GlucoseTrayCore.Views
             // 
             this.checkBox_debug_mode.AutoSize = true;
             this.checkBox_debug_mode.Dock = System.Windows.Forms.DockStyle.Top;
-            this.checkBox_debug_mode.Location = new System.Drawing.Point(162, 123);
+            this.checkBox_debug_mode.Location = new System.Drawing.Point(157, 123);
             this.checkBox_debug_mode.Name = "checkBox_debug_mode";
-            this.checkBox_debug_mode.Size = new System.Drawing.Size(146, 21);
+            this.checkBox_debug_mode.Size = new System.Drawing.Size(141, 21);
             this.checkBox_debug_mode.TabIndex = 7;
             this.checkBox_debug_mode.UseVisualStyleBackColor = true;
             // 
@@ -633,7 +633,7 @@ namespace GlucoseTrayCore.Views
             // 
             // numeric_stale_results
             // 
-            this.numeric_stale_results.Location = new System.Drawing.Point(314, 43);
+            this.numeric_stale_results.Location = new System.Drawing.Point(304, 43);
             this.numeric_stale_results.Maximum = new decimal(new int[] {
             9999,
             0,
@@ -652,9 +652,9 @@ namespace GlucoseTrayCore.Views
             // 
             this.tableLayoutPanel1.SetColumnSpan(this.textBox_db_location_result, 2);
             this.textBox_db_location_result.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.textBox_db_location_result.Location = new System.Drawing.Point(162, 163);
+            this.textBox_db_location_result.Location = new System.Drawing.Point(157, 163);
             this.textBox_db_location_result.Name = "textBox_db_location_result";
-            this.textBox_db_location_result.Size = new System.Drawing.Size(302, 31);
+            this.textBox_db_location_result.Size = new System.Drawing.Size(307, 31);
             this.textBox_db_location_result.TabIndex = 10;
             this.textBox_db_location_result.Text = "C:\\temp\\glucosetray.db";
             // 

--- a/GlucoseTrayCore/Views/Settings.Designer.cs
+++ b/GlucoseTrayCore/Views/Settings.Designer.cs
@@ -1,0 +1,744 @@
+﻿
+namespace GlucoseTrayCore.Views
+{
+    partial class Settings
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.radio_dexcom = new System.Windows.Forms.RadioButton();
+            this.radio_nightscout = new System.Windows.Forms.RadioButton();
+            this.label_glucose_fetch = new System.Windows.Forms.Label();
+            this.datasource_grid = new System.Windows.Forms.TableLayoutPanel();
+            this.dexcom_settings_grid = new System.Windows.Forms.TableLayoutPanel();
+            this.radio_dexcom_server_us_share2 = new System.Windows.Forms.RadioButton();
+            this.label_dexcom_username = new System.Windows.Forms.Label();
+            this.label_dexcom_password = new System.Windows.Forms.Label();
+            this.textBox_dexcom_username = new System.Windows.Forms.TextBox();
+            this.label_dexcom_server = new System.Windows.Forms.Label();
+            this.radio_dexcom_server_us_share1 = new System.Windows.Forms.RadioButton();
+            this.radio_dexcom_server_international = new System.Windows.Forms.RadioButton();
+            this.maskedText_dexcom_password = new System.Windows.Forms.MaskedTextBox();
+            this.nightscout_grid = new System.Windows.Forms.TableLayoutPanel();
+            this.label_nightscout_url = new System.Windows.Forms.Label();
+            this.label_nightscout_token = new System.Windows.Forms.Label();
+            this.textBox_nightscout_url = new System.Windows.Forms.TextBox();
+            this.textBox_nightscout_token = new System.Windows.Forms.TextBox();
+            this.glucose_unit_grid = new System.Windows.Forms.TableLayoutPanel();
+            this.radio_glucose_unit_mmol = new System.Windows.Forms.RadioButton();
+            this.label_glucose_unit = new System.Windows.Forms.Label();
+            this.radio_glucose_unit_mg = new System.Windows.Forms.RadioButton();
+            this.glucose_values_grid = new System.Windows.Forms.TableLayoutPanel();
+            this.label_glucose_thresholds = new System.Windows.Forms.Label();
+            this.label_glucose_high = new System.Windows.Forms.Label();
+            this.label_glucose_warning_high = new System.Windows.Forms.Label();
+            this.label_glucose_warning_low = new System.Windows.Forms.Label();
+            this.label_glucose_low = new System.Windows.Forms.Label();
+            this.label_glucose_critical = new System.Windows.Forms.Label();
+            this.numeric_glucose_high = new System.Windows.Forms.NumericUpDown();
+            this.numeric_glucose_warning_high = new System.Windows.Forms.NumericUpDown();
+            this.numeric_glucose_warning_low = new System.Windows.Forms.NumericUpDown();
+            this.numeric_glucose_low = new System.Windows.Forms.NumericUpDown();
+            this.numeric_glucose_critical = new System.Windows.Forms.NumericUpDown();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.numeric_polling_threshold = new System.Windows.Forms.NumericUpDown();
+            this.label_polling_threshold = new System.Windows.Forms.Label();
+            this.label_stale_results = new System.Windows.Forms.Label();
+            this.label_log_level = new System.Windows.Forms.Label();
+            this.comboBox_log_level = new System.Windows.Forms.ComboBox();
+            this.label_debug_mode = new System.Windows.Forms.Label();
+            this.checkBox_debug_mode = new System.Windows.Forms.CheckBox();
+            this.label_db_location = new System.Windows.Forms.Label();
+            this.numeric_stale_results = new System.Windows.Forms.NumericUpDown();
+            this.textBox_db_location_result = new System.Windows.Forms.TextBox();
+            this.datasource_grid.SuspendLayout();
+            this.dexcom_settings_grid.SuspendLayout();
+            this.nightscout_grid.SuspendLayout();
+            this.glucose_unit_grid.SuspendLayout();
+            this.glucose_values_grid.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.numeric_glucose_high)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numeric_glucose_warning_high)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numeric_glucose_warning_low)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numeric_glucose_low)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numeric_glucose_critical)).BeginInit();
+            this.tableLayoutPanel1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.numeric_polling_threshold)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numeric_stale_results)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // radio_dexcom
+            // 
+            this.radio_dexcom.AutoSize = true;
+            this.radio_dexcom.Dock = System.Windows.Forms.DockStyle.Right;
+            this.radio_dexcom.Location = new System.Drawing.Point(45, 41);
+            this.radio_dexcom.Name = "radio_dexcom";
+            this.radio_dexcom.Size = new System.Drawing.Size(102, 33);
+            this.radio_dexcom.TabIndex = 0;
+            this.radio_dexcom.TabStop = true;
+            this.radio_dexcom.Text = "Dexcom";
+            this.radio_dexcom.UseVisualStyleBackColor = true;
+            this.radio_dexcom.CheckedChanged += new System.EventHandler(this.radio_dexcom_CheckedChanged);
+            // 
+            // radio_nightscout
+            // 
+            this.radio_nightscout.AutoSize = true;
+            this.radio_nightscout.Dock = System.Windows.Forms.DockStyle.Right;
+            this.radio_nightscout.Location = new System.Drawing.Point(173, 41);
+            this.radio_nightscout.Name = "radio_nightscout";
+            this.radio_nightscout.Size = new System.Drawing.Size(124, 33);
+            this.radio_nightscout.TabIndex = 1;
+            this.radio_nightscout.TabStop = true;
+            this.radio_nightscout.Text = "Nightscout";
+            this.radio_nightscout.UseVisualStyleBackColor = true;
+            this.radio_nightscout.CheckedChanged += new System.EventHandler(this.radio_nightscout_CheckedChanged);
+            // 
+            // label_glucose_fetch
+            // 
+            this.label_glucose_fetch.AutoSize = true;
+            this.datasource_grid.SetColumnSpan(this.label_glucose_fetch, 2);
+            this.label_glucose_fetch.Location = new System.Drawing.Point(3, 0);
+            this.label_glucose_fetch.Name = "label_glucose_fetch";
+            this.label_glucose_fetch.Size = new System.Drawing.Size(168, 25);
+            this.label_glucose_fetch.TabIndex = 2;
+            this.label_glucose_fetch.Text = "Glucose Datasource";
+            // 
+            // datasource_grid
+            // 
+            this.datasource_grid.ColumnCount = 2;
+            this.datasource_grid.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50.33333F));
+            this.datasource_grid.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 49.66667F));
+            this.datasource_grid.Controls.Add(this.label_glucose_fetch, 0, 0);
+            this.datasource_grid.Controls.Add(this.radio_nightscout, 1, 1);
+            this.datasource_grid.Controls.Add(this.radio_dexcom, 0, 1);
+            this.datasource_grid.Location = new System.Drawing.Point(12, 12);
+            this.datasource_grid.Name = "datasource_grid";
+            this.datasource_grid.RowCount = 2;
+            this.datasource_grid.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.datasource_grid.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.datasource_grid.Size = new System.Drawing.Size(300, 77);
+            this.datasource_grid.TabIndex = 3;
+            // 
+            // dexcom_settings_grid
+            // 
+            this.dexcom_settings_grid.ColumnCount = 2;
+            this.dexcom_settings_grid.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.dexcom_settings_grid.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.dexcom_settings_grid.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.dexcom_settings_grid.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.dexcom_settings_grid.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.dexcom_settings_grid.Controls.Add(this.radio_dexcom_server_us_share2, 1, 3);
+            this.dexcom_settings_grid.Controls.Add(this.label_dexcom_username, 0, 0);
+            this.dexcom_settings_grid.Controls.Add(this.label_dexcom_password, 1, 0);
+            this.dexcom_settings_grid.Controls.Add(this.textBox_dexcom_username, 0, 1);
+            this.dexcom_settings_grid.Controls.Add(this.label_dexcom_server, 0, 2);
+            this.dexcom_settings_grid.Controls.Add(this.radio_dexcom_server_us_share1, 1, 2);
+            this.dexcom_settings_grid.Controls.Add(this.radio_dexcom_server_international, 1, 4);
+            this.dexcom_settings_grid.Controls.Add(this.maskedText_dexcom_password, 1, 1);
+            this.dexcom_settings_grid.Location = new System.Drawing.Point(319, 12);
+            this.dexcom_settings_grid.Name = "dexcom_settings_grid";
+            this.dexcom_settings_grid.RowCount = 5;
+            this.dexcom_settings_grid.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 39.47368F));
+            this.dexcom_settings_grid.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 60.52632F));
+            this.dexcom_settings_grid.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 33F));
+            this.dexcom_settings_grid.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 34F));
+            this.dexcom_settings_grid.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 36F));
+            this.dexcom_settings_grid.Size = new System.Drawing.Size(363, 176);
+            this.dexcom_settings_grid.TabIndex = 4;
+            this.dexcom_settings_grid.Visible = false;
+            // 
+            // radio_dexcom_server_us_share2
+            // 
+            this.radio_dexcom_server_us_share2.AutoSize = true;
+            this.radio_dexcom_server_us_share2.Location = new System.Drawing.Point(184, 108);
+            this.radio_dexcom_server_us_share2.Name = "radio_dexcom_server_us_share2";
+            this.radio_dexcom_server_us_share2.Size = new System.Drawing.Size(123, 28);
+            this.radio_dexcom_server_us_share2.TabIndex = 5;
+            this.radio_dexcom_server_us_share2.TabStop = true;
+            this.radio_dexcom_server_us_share2.Text = "US Share 2";
+            this.radio_dexcom_server_us_share2.UseVisualStyleBackColor = true;
+            // 
+            // label_dexcom_username
+            // 
+            this.label_dexcom_username.AutoSize = true;
+            this.label_dexcom_username.Location = new System.Drawing.Point(3, 0);
+            this.label_dexcom_username.Name = "label_dexcom_username";
+            this.label_dexcom_username.Size = new System.Drawing.Size(161, 25);
+            this.label_dexcom_username.TabIndex = 0;
+            this.label_dexcom_username.Text = "Dexcom Username";
+            // 
+            // label_dexcom_password
+            // 
+            this.label_dexcom_password.AutoSize = true;
+            this.label_dexcom_password.Location = new System.Drawing.Point(184, 0);
+            this.label_dexcom_password.Name = "label_dexcom_password";
+            this.label_dexcom_password.Size = new System.Drawing.Size(157, 25);
+            this.label_dexcom_password.TabIndex = 1;
+            this.label_dexcom_password.Text = "Dexcom Password";
+            // 
+            // textBox_dexcom_username
+            // 
+            this.textBox_dexcom_username.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.textBox_dexcom_username.Location = new System.Drawing.Point(3, 31);
+            this.textBox_dexcom_username.Name = "textBox_dexcom_username";
+            this.textBox_dexcom_username.Size = new System.Drawing.Size(175, 31);
+            this.textBox_dexcom_username.TabIndex = 2;
+            // 
+            // label_dexcom_server
+            // 
+            this.label_dexcom_server.AutoSize = true;
+            this.label_dexcom_server.Location = new System.Drawing.Point(3, 72);
+            this.label_dexcom_server.Name = "label_dexcom_server";
+            this.label_dexcom_server.Size = new System.Drawing.Size(131, 25);
+            this.label_dexcom_server.TabIndex = 4;
+            this.label_dexcom_server.Text = "Dexcom Server";
+            // 
+            // radio_dexcom_server_us_share1
+            // 
+            this.radio_dexcom_server_us_share1.AutoSize = true;
+            this.radio_dexcom_server_us_share1.Location = new System.Drawing.Point(184, 75);
+            this.radio_dexcom_server_us_share1.Name = "radio_dexcom_server_us_share1";
+            this.radio_dexcom_server_us_share1.Size = new System.Drawing.Size(123, 27);
+            this.radio_dexcom_server_us_share1.TabIndex = 5;
+            this.radio_dexcom_server_us_share1.TabStop = true;
+            this.radio_dexcom_server_us_share1.Text = "US Share 1";
+            this.radio_dexcom_server_us_share1.UseVisualStyleBackColor = true;
+            // 
+            // radio_dexcom_server_international
+            // 
+            this.radio_dexcom_server_international.AutoSize = true;
+            this.radio_dexcom_server_international.Location = new System.Drawing.Point(184, 142);
+            this.radio_dexcom_server_international.Name = "radio_dexcom_server_international";
+            this.radio_dexcom_server_international.Size = new System.Drawing.Size(136, 29);
+            this.radio_dexcom_server_international.TabIndex = 6;
+            this.radio_dexcom_server_international.TabStop = true;
+            this.radio_dexcom_server_international.Text = "International";
+            this.radio_dexcom_server_international.UseVisualStyleBackColor = true;
+            // 
+            // maskedText_dexcom_password
+            // 
+            this.maskedText_dexcom_password.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.maskedText_dexcom_password.Location = new System.Drawing.Point(184, 31);
+            this.maskedText_dexcom_password.Name = "maskedText_dexcom_password";
+            this.maskedText_dexcom_password.Size = new System.Drawing.Size(176, 31);
+            this.maskedText_dexcom_password.TabIndex = 7;
+            this.maskedText_dexcom_password.UseSystemPasswordChar = true;
+            // 
+            // nightscout_grid
+            // 
+            this.nightscout_grid.ColumnCount = 2;
+            this.nightscout_grid.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.nightscout_grid.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.nightscout_grid.Controls.Add(this.label_nightscout_url, 0, 0);
+            this.nightscout_grid.Controls.Add(this.label_nightscout_token, 0, 1);
+            this.nightscout_grid.Controls.Add(this.textBox_nightscout_url, 1, 0);
+            this.nightscout_grid.Controls.Add(this.textBox_nightscout_token, 1, 1);
+            this.nightscout_grid.Location = new System.Drawing.Point(319, 12);
+            this.nightscout_grid.Name = "nightscout_grid";
+            this.nightscout_grid.RowCount = 2;
+            this.nightscout_grid.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.nightscout_grid.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.nightscout_grid.Size = new System.Drawing.Size(454, 97);
+            this.nightscout_grid.TabIndex = 5;
+            this.nightscout_grid.Visible = false;
+            // 
+            // label_nightscout_url
+            // 
+            this.label_nightscout_url.AutoSize = true;
+            this.label_nightscout_url.Location = new System.Drawing.Point(3, 0);
+            this.label_nightscout_url.Name = "label_nightscout_url";
+            this.label_nightscout_url.Size = new System.Drawing.Size(126, 25);
+            this.label_nightscout_url.TabIndex = 0;
+            this.label_nightscout_url.Text = "Nightscout Url";
+            // 
+            // label_nightscout_token
+            // 
+            this.label_nightscout_token.AutoSize = true;
+            this.label_nightscout_token.Location = new System.Drawing.Point(3, 48);
+            this.label_nightscout_token.Name = "label_nightscout_token";
+            this.label_nightscout_token.Size = new System.Drawing.Size(208, 25);
+            this.label_nightscout_token.TabIndex = 1;
+            this.label_nightscout_token.Text = "Nightscout Access Token";
+            // 
+            // textBox_nightscout_url
+            // 
+            this.textBox_nightscout_url.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.textBox_nightscout_url.Location = new System.Drawing.Point(230, 3);
+            this.textBox_nightscout_url.Name = "textBox_nightscout_url";
+            this.textBox_nightscout_url.Size = new System.Drawing.Size(221, 31);
+            this.textBox_nightscout_url.TabIndex = 2;
+            // 
+            // textBox_nightscout_token
+            // 
+            this.textBox_nightscout_token.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.textBox_nightscout_token.Location = new System.Drawing.Point(230, 51);
+            this.textBox_nightscout_token.Name = "textBox_nightscout_token";
+            this.textBox_nightscout_token.Size = new System.Drawing.Size(221, 31);
+            this.textBox_nightscout_token.TabIndex = 3;
+            // 
+            // glucose_unit_grid
+            // 
+            this.glucose_unit_grid.ColumnCount = 2;
+            this.glucose_unit_grid.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50.16835F));
+            this.glucose_unit_grid.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 49.83165F));
+            this.glucose_unit_grid.Controls.Add(this.radio_glucose_unit_mmol, 1, 1);
+            this.glucose_unit_grid.Controls.Add(this.label_glucose_unit, 0, 0);
+            this.glucose_unit_grid.Controls.Add(this.radio_glucose_unit_mg, 0, 1);
+            this.glucose_unit_grid.Location = new System.Drawing.Point(12, 110);
+            this.glucose_unit_grid.Name = "glucose_unit_grid";
+            this.glucose_unit_grid.RowCount = 2;
+            this.glucose_unit_grid.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.glucose_unit_grid.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.glucose_unit_grid.Size = new System.Drawing.Size(297, 78);
+            this.glucose_unit_grid.TabIndex = 6;
+            // 
+            // radio_glucose_unit_mmol
+            // 
+            this.radio_glucose_unit_mmol.AutoSize = true;
+            this.radio_glucose_unit_mmol.Dock = System.Windows.Forms.DockStyle.Right;
+            this.radio_glucose_unit_mmol.Location = new System.Drawing.Point(184, 42);
+            this.radio_glucose_unit_mmol.Name = "radio_glucose_unit_mmol";
+            this.radio_glucose_unit_mmol.Size = new System.Drawing.Size(110, 33);
+            this.radio_glucose_unit_mmol.TabIndex = 1;
+            this.radio_glucose_unit_mmol.TabStop = true;
+            this.radio_glucose_unit_mmol.Text = "MMOG/L";
+            this.radio_glucose_unit_mmol.UseVisualStyleBackColor = true;
+            this.radio_glucose_unit_mmol.CheckedChanged += new System.EventHandler(this.radio_glucose_unit_mmol_CheckedChanged);
+            // 
+            // label_glucose_unit
+            // 
+            this.label_glucose_unit.AutoSize = true;
+            this.glucose_unit_grid.SetColumnSpan(this.label_glucose_unit, 2);
+            this.label_glucose_unit.Location = new System.Drawing.Point(3, 0);
+            this.label_glucose_unit.Name = "label_glucose_unit";
+            this.label_glucose_unit.Size = new System.Drawing.Size(111, 25);
+            this.label_glucose_unit.TabIndex = 0;
+            this.label_glucose_unit.Text = "Glucose Unit";
+            // 
+            // radio_glucose_unit_mg
+            // 
+            this.radio_glucose_unit_mg.AutoSize = true;
+            this.radio_glucose_unit_mg.Dock = System.Windows.Forms.DockStyle.Right;
+            this.radio_glucose_unit_mg.Location = new System.Drawing.Point(53, 42);
+            this.radio_glucose_unit_mg.Name = "radio_glucose_unit_mg";
+            this.radio_glucose_unit_mg.Size = new System.Drawing.Size(93, 33);
+            this.radio_glucose_unit_mg.TabIndex = 2;
+            this.radio_glucose_unit_mg.TabStop = true;
+            this.radio_glucose_unit_mg.Text = "MG/DL";
+            this.radio_glucose_unit_mg.UseVisualStyleBackColor = true;
+            this.radio_glucose_unit_mg.CheckedChanged += new System.EventHandler(this.radio_glucose_unit_mg_CheckedChanged);
+            // 
+            // glucose_values_grid
+            // 
+            this.glucose_values_grid.ColumnCount = 2;
+            this.glucose_values_grid.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 61.06557F));
+            this.glucose_values_grid.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 38.93443F));
+            this.glucose_values_grid.Controls.Add(this.label_glucose_thresholds, 0, 0);
+            this.glucose_values_grid.Controls.Add(this.label_glucose_high, 0, 1);
+            this.glucose_values_grid.Controls.Add(this.label_glucose_warning_high, 0, 2);
+            this.glucose_values_grid.Controls.Add(this.label_glucose_warning_low, 0, 3);
+            this.glucose_values_grid.Controls.Add(this.label_glucose_low, 0, 4);
+            this.glucose_values_grid.Controls.Add(this.label_glucose_critical, 0, 5);
+            this.glucose_values_grid.Controls.Add(this.numeric_glucose_high, 1, 1);
+            this.glucose_values_grid.Controls.Add(this.numeric_glucose_warning_high, 1, 2);
+            this.glucose_values_grid.Controls.Add(this.numeric_glucose_warning_low, 1, 3);
+            this.glucose_values_grid.Controls.Add(this.numeric_glucose_low, 1, 4);
+            this.glucose_values_grid.Controls.Add(this.numeric_glucose_critical, 1, 5);
+            this.glucose_values_grid.Enabled = false;
+            this.glucose_values_grid.Location = new System.Drawing.Point(12, 218);
+            this.glucose_values_grid.Name = "glucose_values_grid";
+            this.glucose_values_grid.RowCount = 6;
+            this.glucose_values_grid.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 45F));
+            this.glucose_values_grid.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
+            this.glucose_values_grid.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
+            this.glucose_values_grid.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
+            this.glucose_values_grid.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
+            this.glucose_values_grid.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
+            this.glucose_values_grid.Size = new System.Drawing.Size(244, 247);
+            this.glucose_values_grid.TabIndex = 7;
+            // 
+            // label_glucose_thresholds
+            // 
+            this.label_glucose_thresholds.AutoSize = true;
+            this.glucose_values_grid.SetColumnSpan(this.label_glucose_thresholds, 2);
+            this.label_glucose_thresholds.Location = new System.Drawing.Point(3, 0);
+            this.label_glucose_thresholds.Name = "label_glucose_thresholds";
+            this.label_glucose_thresholds.Size = new System.Drawing.Size(165, 25);
+            this.label_glucose_thresholds.TabIndex = 0;
+            this.label_glucose_thresholds.Text = "Glucose Thresholds";
+            // 
+            // label_glucose_high
+            // 
+            this.label_glucose_high.AutoSize = true;
+            this.label_glucose_high.Location = new System.Drawing.Point(3, 45);
+            this.label_glucose_high.Name = "label_glucose_high";
+            this.label_glucose_high.Size = new System.Drawing.Size(50, 25);
+            this.label_glucose_high.TabIndex = 1;
+            this.label_glucose_high.Text = "High";
+            // 
+            // label_glucose_warning_high
+            // 
+            this.label_glucose_warning_high.AutoSize = true;
+            this.label_glucose_warning_high.Location = new System.Drawing.Point(3, 85);
+            this.label_glucose_warning_high.Name = "label_glucose_warning_high";
+            this.label_glucose_warning_high.Size = new System.Drawing.Size(121, 25);
+            this.label_glucose_warning_high.TabIndex = 2;
+            this.label_glucose_warning_high.Text = "High Warning";
+            // 
+            // label_glucose_warning_low
+            // 
+            this.label_glucose_warning_low.AutoSize = true;
+            this.label_glucose_warning_low.Location = new System.Drawing.Point(3, 125);
+            this.label_glucose_warning_low.Name = "label_glucose_warning_low";
+            this.label_glucose_warning_low.Size = new System.Drawing.Size(115, 25);
+            this.label_glucose_warning_low.TabIndex = 3;
+            this.label_glucose_warning_low.Text = "Low Warning";
+            // 
+            // label_glucose_low
+            // 
+            this.label_glucose_low.AutoSize = true;
+            this.label_glucose_low.Location = new System.Drawing.Point(3, 165);
+            this.label_glucose_low.Name = "label_glucose_low";
+            this.label_glucose_low.Size = new System.Drawing.Size(44, 25);
+            this.label_glucose_low.TabIndex = 4;
+            this.label_glucose_low.Text = "Low";
+            // 
+            // label_glucose_critical
+            // 
+            this.label_glucose_critical.AutoSize = true;
+            this.label_glucose_critical.Location = new System.Drawing.Point(3, 205);
+            this.label_glucose_critical.Name = "label_glucose_critical";
+            this.label_glucose_critical.Size = new System.Drawing.Size(114, 25);
+            this.label_glucose_critical.TabIndex = 5;
+            this.label_glucose_critical.Text = "Critically Low";
+            // 
+            // numeric_glucose_high
+            // 
+            this.numeric_glucose_high.Location = new System.Drawing.Point(151, 48);
+            this.numeric_glucose_high.Maximum = new decimal(new int[] {
+            999,
+            0,
+            0,
+            0});
+            this.numeric_glucose_high.Name = "numeric_glucose_high";
+            this.numeric_glucose_high.Size = new System.Drawing.Size(89, 31);
+            this.numeric_glucose_high.TabIndex = 6;
+            this.numeric_glucose_high.Value = new decimal(new int[] {
+            300,
+            0,
+            0,
+            0});
+            // 
+            // numeric_glucose_warning_high
+            // 
+            this.numeric_glucose_warning_high.Location = new System.Drawing.Point(151, 88);
+            this.numeric_glucose_warning_high.Maximum = new decimal(new int[] {
+            999,
+            0,
+            0,
+            0});
+            this.numeric_glucose_warning_high.Name = "numeric_glucose_warning_high";
+            this.numeric_glucose_warning_high.Size = new System.Drawing.Size(89, 31);
+            this.numeric_glucose_warning_high.TabIndex = 7;
+            this.numeric_glucose_warning_high.Value = new decimal(new int[] {
+            250,
+            0,
+            0,
+            0});
+            // 
+            // numeric_glucose_warning_low
+            // 
+            this.numeric_glucose_warning_low.Location = new System.Drawing.Point(151, 128);
+            this.numeric_glucose_warning_low.Maximum = new decimal(new int[] {
+            999,
+            0,
+            0,
+            0});
+            this.numeric_glucose_warning_low.Name = "numeric_glucose_warning_low";
+            this.numeric_glucose_warning_low.Size = new System.Drawing.Size(89, 31);
+            this.numeric_glucose_warning_low.TabIndex = 8;
+            this.numeric_glucose_warning_low.Value = new decimal(new int[] {
+            80,
+            0,
+            0,
+            0});
+            // 
+            // numeric_glucose_low
+            // 
+            this.numeric_glucose_low.Location = new System.Drawing.Point(151, 168);
+            this.numeric_glucose_low.Maximum = new decimal(new int[] {
+            999,
+            0,
+            0,
+            0});
+            this.numeric_glucose_low.Name = "numeric_glucose_low";
+            this.numeric_glucose_low.Size = new System.Drawing.Size(89, 31);
+            this.numeric_glucose_low.TabIndex = 9;
+            this.numeric_glucose_low.Value = new decimal(new int[] {
+            70,
+            0,
+            0,
+            0});
+            // 
+            // numeric_glucose_critical
+            // 
+            this.numeric_glucose_critical.Location = new System.Drawing.Point(151, 208);
+            this.numeric_glucose_critical.Maximum = new decimal(new int[] {
+            999,
+            0,
+            0,
+            0});
+            this.numeric_glucose_critical.Name = "numeric_glucose_critical";
+            this.numeric_glucose_critical.Size = new System.Drawing.Size(89, 31);
+            this.numeric_glucose_critical.TabIndex = 10;
+            this.numeric_glucose_critical.Value = new decimal(new int[] {
+            55,
+            0,
+            0,
+            0});
+            // 
+            // tableLayoutPanel1
+            // 
+            this.tableLayoutPanel1.ColumnCount = 3;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 51.23457F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 48.76543F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 144F));
+            this.tableLayoutPanel1.Controls.Add(this.numeric_polling_threshold, 1, 0);
+            this.tableLayoutPanel1.Controls.Add(this.label_polling_threshold, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.label_stale_results, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.label_log_level, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.comboBox_log_level, 1, 2);
+            this.tableLayoutPanel1.Controls.Add(this.label_debug_mode, 0, 3);
+            this.tableLayoutPanel1.Controls.Add(this.checkBox_debug_mode, 1, 3);
+            this.tableLayoutPanel1.Controls.Add(this.label_db_location, 0, 4);
+            this.tableLayoutPanel1.Controls.Add(this.numeric_stale_results, 2, 1);
+            this.tableLayoutPanel1.Controls.Add(this.textBox_db_location_result, 1, 4);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(306, 218);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.RowCount = 5;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(467, 199);
+            this.tableLayoutPanel1.TabIndex = 8;
+            // 
+            // numeric_polling_threshold
+            // 
+            this.numeric_polling_threshold.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.numeric_polling_threshold.Location = new System.Drawing.Point(325, 3);
+            this.numeric_polling_threshold.Maximum = new decimal(new int[] {
+            99999,
+            0,
+            0,
+            0});
+            this.numeric_polling_threshold.Name = "numeric_polling_threshold";
+            this.numeric_polling_threshold.Size = new System.Drawing.Size(139, 31);
+            this.numeric_polling_threshold.TabIndex = 9;
+            this.numeric_polling_threshold.Value = new decimal(new int[] {
+            15,
+            0,
+            0,
+            0});
+            // 
+            // label_polling_threshold
+            // 
+            this.label_polling_threshold.AutoSize = true;
+            this.tableLayoutPanel1.SetColumnSpan(this.label_polling_threshold, 2);
+            this.label_polling_threshold.Location = new System.Drawing.Point(3, 0);
+            this.label_polling_threshold.Name = "label_polling_threshold";
+            this.label_polling_threshold.Size = new System.Drawing.Size(185, 25);
+            this.label_polling_threshold.TabIndex = 0;
+            this.label_polling_threshold.Text = "Polling Rate (seconds)";
+            // 
+            // label_stale_results
+            // 
+            this.label_stale_results.AutoSize = true;
+            this.tableLayoutPanel1.SetColumnSpan(this.label_stale_results, 2);
+            this.label_stale_results.Location = new System.Drawing.Point(3, 40);
+            this.label_stale_results.Name = "label_stale_results";
+            this.label_stale_results.Size = new System.Drawing.Size(308, 25);
+            this.label_stale_results.TabIndex = 2;
+            this.label_stale_results.Text = "Consider Results State After (minutes)";
+            // 
+            // label_log_level
+            // 
+            this.label_log_level.AutoSize = true;
+            this.tableLayoutPanel1.SetColumnSpan(this.label_log_level, 2);
+            this.label_log_level.Location = new System.Drawing.Point(3, 80);
+            this.label_log_level.Name = "label_log_level";
+            this.label_log_level.Size = new System.Drawing.Size(122, 25);
+            this.label_log_level.TabIndex = 4;
+            this.label_log_level.Text = "Logging Level";
+            // 
+            // comboBox_log_level
+            // 
+            this.comboBox_log_level.FormattingEnabled = true;
+            this.comboBox_log_level.Location = new System.Drawing.Point(325, 83);
+            this.comboBox_log_level.Name = "comboBox_log_level";
+            this.comboBox_log_level.Size = new System.Drawing.Size(137, 33);
+            this.comboBox_log_level.TabIndex = 5;
+            // 
+            // label_debug_mode
+            // 
+            this.label_debug_mode.AutoSize = true;
+            this.label_debug_mode.Location = new System.Drawing.Point(3, 120);
+            this.label_debug_mode.Name = "label_debug_mode";
+            this.label_debug_mode.Size = new System.Drawing.Size(118, 25);
+            this.label_debug_mode.TabIndex = 6;
+            this.label_debug_mode.Text = "Debug Mode";
+            // 
+            // checkBox_debug_mode
+            // 
+            this.checkBox_debug_mode.AutoSize = true;
+            this.checkBox_debug_mode.Dock = System.Windows.Forms.DockStyle.Top;
+            this.checkBox_debug_mode.Location = new System.Drawing.Point(168, 123);
+            this.checkBox_debug_mode.Name = "checkBox_debug_mode";
+            this.checkBox_debug_mode.Size = new System.Drawing.Size(151, 21);
+            this.checkBox_debug_mode.TabIndex = 7;
+            this.checkBox_debug_mode.UseVisualStyleBackColor = true;
+            // 
+            // label_db_location
+            // 
+            this.label_db_location.AutoSize = true;
+            this.label_db_location.Location = new System.Drawing.Point(3, 160);
+            this.label_db_location.Name = "label_db_location";
+            this.label_db_location.Size = new System.Drawing.Size(158, 25);
+            this.label_db_location.TabIndex = 8;
+            this.label_db_location.Text = "Database Location";
+            // 
+            // numeric_stale_results
+            // 
+            this.numeric_stale_results.Location = new System.Drawing.Point(325, 43);
+            this.numeric_stale_results.Maximum = new decimal(new int[] {
+            9999,
+            0,
+            0,
+            0});
+            this.numeric_stale_results.Name = "numeric_stale_results";
+            this.numeric_stale_results.Size = new System.Drawing.Size(137, 31);
+            this.numeric_stale_results.TabIndex = 3;
+            this.numeric_stale_results.Value = new decimal(new int[] {
+            15,
+            0,
+            0,
+            0});
+            // 
+            // textBox_db_location_result
+            // 
+            this.tableLayoutPanel1.SetColumnSpan(this.textBox_db_location_result, 2);
+            this.textBox_db_location_result.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.textBox_db_location_result.Location = new System.Drawing.Point(168, 163);
+            this.textBox_db_location_result.Name = "textBox_db_location_result";
+            this.textBox_db_location_result.Size = new System.Drawing.Size(296, 31);
+            this.textBox_db_location_result.TabIndex = 10;
+            this.textBox_db_location_result.Text = "C:\\temp\\glucosetray.db";
+            // 
+            // Settings
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 25F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(800, 582);
+            this.Controls.Add(this.tableLayoutPanel1);
+            this.Controls.Add(this.dexcom_settings_grid);
+            this.Controls.Add(this.glucose_values_grid);
+            this.Controls.Add(this.glucose_unit_grid);
+            this.Controls.Add(this.nightscout_grid);
+            this.Controls.Add(this.datasource_grid);
+            this.Name = "Settings";
+            this.Text = "Settings";
+            this.datasource_grid.ResumeLayout(false);
+            this.datasource_grid.PerformLayout();
+            this.dexcom_settings_grid.ResumeLayout(false);
+            this.dexcom_settings_grid.PerformLayout();
+            this.nightscout_grid.ResumeLayout(false);
+            this.nightscout_grid.PerformLayout();
+            this.glucose_unit_grid.ResumeLayout(false);
+            this.glucose_unit_grid.PerformLayout();
+            this.glucose_values_grid.ResumeLayout(false);
+            this.glucose_values_grid.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.numeric_glucose_high)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numeric_glucose_warning_high)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numeric_glucose_warning_low)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numeric_glucose_low)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numeric_glucose_critical)).EndInit();
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.numeric_polling_threshold)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numeric_stale_results)).EndInit();
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.RadioButton radio_dexcom;
+        private System.Windows.Forms.RadioButton radio_nightscout;
+        private System.Windows.Forms.Label label_glucose_fetch;
+        private System.Windows.Forms.TableLayoutPanel datasource_grid;
+        private System.Windows.Forms.TableLayoutPanel dexcom_settings_grid;
+        private System.Windows.Forms.Label label_dexcom_username;
+        private System.Windows.Forms.Label label_dexcom_password;
+        private System.Windows.Forms.TextBox textBox_dexcom_username;
+        private System.Windows.Forms.Label label_dexcom_server;
+        private System.Windows.Forms.RadioButton radio_dexcom_server_us_share1;
+        private System.Windows.Forms.RadioButton radio_dexcom_server_us_share2;
+        private System.Windows.Forms.RadioButton radio_dexcom_server_international;
+        private System.Windows.Forms.TableLayoutPanel nightscout_grid;
+        private System.Windows.Forms.Label label_nightscout_url;
+        private System.Windows.Forms.Label label_nightscout_token;
+        private System.Windows.Forms.TextBox textBox_nightscout_url;
+        private System.Windows.Forms.TextBox textBox_nightscout_token;
+        private System.Windows.Forms.TableLayoutPanel glucose_unit_grid;
+        private System.Windows.Forms.RadioButton radio_glucose_unit_mmol;
+        private System.Windows.Forms.Label label_glucose_unit;
+        private System.Windows.Forms.RadioButton radio_glucose_unit_mg;
+        private System.Windows.Forms.TableLayoutPanel glucose_values_grid;
+        private System.Windows.Forms.Label label_glucose_thresholds;
+        private System.Windows.Forms.Label label_glucose_high;
+        private System.Windows.Forms.Label label_glucose_warning_high;
+        private System.Windows.Forms.MaskedTextBox maskedText_dexcom_password;
+        private System.Windows.Forms.Label label_glucose_warning_low;
+        private System.Windows.Forms.Label label_glucose_low;
+        private System.Windows.Forms.Label label_glucose_critical;
+        private System.Windows.Forms.NumericUpDown numeric_glucose_high;
+        private System.Windows.Forms.NumericUpDown numeric_glucose_warning_high;
+        private System.Windows.Forms.NumericUpDown numeric_glucose_warning_low;
+        private System.Windows.Forms.NumericUpDown numeric_glucose_low;
+        private System.Windows.Forms.NumericUpDown numeric_glucose_critical;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private System.Windows.Forms.Label label_polling_threshold;
+        private System.Windows.Forms.Label label_stale_results;
+        private System.Windows.Forms.NumericUpDown numeric_stale_results;
+        private System.Windows.Forms.Label label_log_level;
+        private System.Windows.Forms.ComboBox comboBox_log_level;
+        private System.Windows.Forms.Label label_debug_mode;
+        private System.Windows.Forms.CheckBox checkBox_debug_mode;
+        private System.Windows.Forms.Label label_db_location;
+        private System.Windows.Forms.NumericUpDown numeric_polling_threshold;
+        private System.Windows.Forms.TextBox textBox_db_location_result;
+    }
+}

--- a/GlucoseTrayCore/Views/Settings.cs
+++ b/GlucoseTrayCore/Views/Settings.cs
@@ -89,5 +89,13 @@ namespace GlucoseTrayCore.Views
                 }
             }
         }
+
+        private void button_save_Click(object sender, EventArgs e)
+        {
+
+            // If everything is valid, save and return an OK result
+            Close();
+            DialogResult = DialogResult.OK;
+        }
     }
 }

--- a/GlucoseTrayCore/Views/Settings.cs
+++ b/GlucoseTrayCore/Views/Settings.cs
@@ -70,9 +70,9 @@ namespace GlucoseTrayCore.Views
                     textBox_nightscout_url.Text = model.NightscoutUrl;
 
                     numeric_glucose_critical.Value = (decimal)model.CriticalLowBg;
-                    numeric_glucose_high.Value = (decimal)model.HighBg;
+                    numeric_glucose_high.Value = (decimal)model.WarningHighBg;
                     numeric_glucose_low.Value = (decimal)model.LowBg;
-                    numeric_glucose_warning_high.Value = (decimal)model.DangerHighBg;
+                    numeric_glucose_warning_high.Value = (decimal)model.HighBg;
                     numeric_glucose_warning_low.Value = (decimal)model.WarningLowBg;
 
                     numeric_polling_threshold.Value = model.PollingThreshold;
@@ -155,10 +155,10 @@ namespace GlucoseTrayCore.Views
                 DexcomPassword = maskedText_dexcom_password.Text, // TODO: Hash? How will that affect deserialization?
                 DexcomServer = radio_dexcom_server_us_share1.Checked ? DexcomServerLocation.DexcomShare1 : radio_dexcom_server_us_share2.Checked ? DexcomServerLocation.DexcomShare2 : DexcomServerLocation.DexcomInternational,
                 CriticalLowBg = (double) numeric_glucose_critical.Value,
-                DangerHighBg = (double) numeric_glucose_warning_high.Value,
+                HighBg = (double) numeric_glucose_warning_high.Value,
                 LowBg = (double) numeric_glucose_low.Value,
                 WarningLowBg = (double) numeric_glucose_warning_low.Value,
-                HighBg = (double) numeric_glucose_high.Value,
+                WarningHighBg = (double) numeric_glucose_high.Value,
                 GlucoseUnit = radio_glucose_unit_mg.Checked ? GlucoseUnitType.MG : GlucoseUnitType.MMOL,
                 DatabaseLocation = textBox_db_location_result.Text,
                 EnableDebugMode = checkBox_debug_mode.Checked,

--- a/GlucoseTrayCore/Views/Settings.cs
+++ b/GlucoseTrayCore/Views/Settings.cs
@@ -92,8 +92,11 @@ namespace GlucoseTrayCore.Views
 
         private void button_save_Click(object sender, EventArgs e)
         {
-
             // If everything is valid, save and return an OK result
+
+            // TODO: Convert our settings to JSON and write to file. (mirron the appsettings.json file)
+            var settingsFile = Program.SettingsFile;
+
             Close();
             DialogResult = DialogResult.OK;
         }

--- a/GlucoseTrayCore/Views/Settings.cs
+++ b/GlucoseTrayCore/Views/Settings.cs
@@ -1,0 +1,93 @@
+﻿using Serilog.Events;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace GlucoseTrayCore.Views
+{
+    public partial class Settings : Form
+    {
+        private bool? SelectedGlucoseTypeIsMG;
+
+        public static readonly Dictionary<string, int> LogLevels = new Dictionary<string, int>
+        {
+            { "Verbose", (int) LogEventLevel.Verbose },
+            { "Debug", (int) LogEventLevel.Debug },
+            { "Informational", (int) LogEventLevel.Information },
+            { "Warning", (int) LogEventLevel.Warning },
+            { "Error", (int) LogEventLevel.Warning },
+            { "Fatal", (int) LogEventLevel.Fatal },
+        };
+
+        public Settings()
+        {
+            InitializeComponent();
+            comboBox_log_level.DataSource = (IList<string>) LogLevels.Select(x => x.Key).ToList();
+        }
+
+        private void radio_dexcom_CheckedChanged(object sender, EventArgs e)
+        {
+            nightscout_grid.Visible = false;
+            dexcom_settings_grid.Visible = true;
+        }
+
+        private void radio_nightscout_CheckedChanged(object sender, EventArgs e)
+        {
+            dexcom_settings_grid.Visible = false;
+            nightscout_grid.Visible = true;
+        }
+
+        private void radio_glucose_unit_mg_CheckedChanged(object sender, EventArgs e)
+        {
+            CalculateGlucoseValues(true);
+            glucose_values_grid.Enabled = true;
+        }
+
+        private void radio_glucose_unit_mmol_CheckedChanged(object sender, EventArgs e)
+        {
+            CalculateGlucoseValues(false);
+            glucose_values_grid.Enabled = true;
+        }
+
+        private void CalculateGlucoseValues(bool setForMG)
+        {
+            if (SelectedGlucoseTypeIsMG == !setForMG)
+                UpdateGlucoseNumericValues(setForMG);
+
+            SelectedGlucoseTypeIsMG = setForMG;
+        }
+
+        private void UpdateGlucoseNumericValues(bool setToMG)
+        {
+            var controls = new [] {
+                numeric_glucose_high, 
+                numeric_glucose_warning_high,
+                numeric_glucose_warning_low,
+                numeric_glucose_low,
+                numeric_glucose_critical
+            };
+
+            foreach(var control in controls)
+            {
+                if (setToMG)
+                {
+                    control.Value *= 18;
+                    control.Increment = 1;
+                    control.DecimalPlaces = 0;
+                }
+                else
+                {
+                    control.DecimalPlaces = 1;
+                    control.Increment = 0.1m;
+                    control.Value /= 18;
+                }
+            }
+        }
+    }
+}

--- a/GlucoseTrayCore/Views/Settings.resx
+++ b/GlucoseTrayCore/Views/Settings.resx
@@ -1,0 +1,60 @@
+﻿<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/GlucoseTrayCore/appsettings.json
+++ b/GlucoseTrayCore/appsettings.json
@@ -1,44 +1,5 @@
 {
   "appsettings": {
-    "Version": "9.1.1",
-
-    "FetchMethod_comments": "Data Fetch Method - 0 for Dexcom auth (Dexcom G6+) or 1 for Nightscout (xDrip+)",
-    "FetchMethod": "0",
-
-    "Dexcom_comments": "Dexcom Auth",
-    "DexcomUsername": "",
-    "DexcomPassword": "",
-
-    "DexcomServer_comments": "Dexcom server - 0 for default (US, share1), 1 for alt (US, share2) or 2 for non-US (shareous1, outside US)",
-    "DexcomServer": "0",
-
-    "Nightscout_comments": "Nightscout Auth",
-    "AccessToken_comments": "If using AUTH_DEFAULT_ROLES = denied in Nightscout configuration, create an access key with at least 'readable' role and enter the token here. Otherwise, leave blank.",
-    "AccessToken": "",
-
-    "MenuConfiguration_comments": "Menu Configurations",
-    "NighscoutUrl_comments": "Required if using Nightscout auth - Enter Nightscout site URL here to use right-click shortcut to site. Ex. https://accountname.herokuapp.com",
-    "NightscoutUrl": "",
-
-    "GlucoseUnit_comments": "Glucose Unit Display (MG/DL = 0 or MMOL/L = 1)",
-    "GlucoseUnit": "0",
-
-    "GlucoseThresholds_comments": "Glucose Thresholds - Based off Glucose Unit Display",
-    "HighBg": "180",
-    "DangerHighBg": "250",
-    "LowBg": "80",
-    "DangerLowBg": "70",
-    "CriticalLowBg": "55",
-
-    "ApplicationSettings_comments": "Application Settings",
-    "PollingThreshold_comments": "Time in seconds between retreiving latest glucose readings.  Dexcom transmitter only updates once every 5 minutes.",
-    "PollingThreshold": "30",
-    "DatabaseLocation": "c:\\TEMP\\glucosetray.db",
-    "EnableDebugMode": "false",
-    "LogLevel_comments": "Verbose = 0, Debug = 1, Information = 2, Warning = 3, Error = 4, Fatal = 5",
-    "LogLevel": "1",
-
-    "StaleResultsThreshold_comments": "Time in minutes before we consider results stale.",
-    "StaleResultsThreshold": "15"
+    "Version": "10.0.0"
   }
 }

--- a/README.md
+++ b/README.md
@@ -11,13 +11,14 @@ Always check with your DexCom reader before making any treatment decisions.
 
 
 <strong>Step-by-step Instructions:</strong> <br>
-Open appsettings.json in your text editor and set your desired values there.  Most important settings are to configure if you are using Nightscout or Dexcom as data source and to enter your site url (NightScout) or credentials (Dexcom).
+Download and run the GlucoseTrayCore.exe
+On first run, you will be prompted to define your settings which will include telling the program where to load your data from.
 
-HighBg displays yellow. <br>
-DangerousHighBg displays red. <br>
-LowBg displays yellow. <br>
-DangerousLowBg displays red. <br>
-CriticalLowBg displays as "DAN" for DANGER. <br>
+High Glucose displays red. <br>
+High Warning Glucose displays yellow. <br>
+Warning Low Glucose displays yellow. <br>
+Low Glucose displays red. <br>
+Critically Low Glucose displays as "DAN" for DANGER and is red. <br>
 Normal blood glucose displays as white. <br>
 Out-of-date readings are shown with a strikethrough effect. <br>
 
@@ -28,6 +29,3 @@ Out-of-date readings are shown with a strikethrough effect. <br>
 -Option to start application on system startup. <br>
 
 ![alt text](https://raw.githubusercontent.com/Delubear/GlucoseTray/master/2019-05-03_16-18-24.png)
-
-
-If missing configuration file, get a new copy at https://github.com/Delubear/GlucoseTray


### PR DESCRIPTION
No more needing to download and mange an appsettings.json file now.

Easier use by using a new modal view to allow changing settings which take affect on the fly after being saved.



Settings are saved to a json file in the users local roaming appData folder.
Settings are validated upon loading and saving and app start.
If settings are missing or invalid, user will be prompted to define settings.

DangerHigh/DangerLow are now High/Low respectively.
The old High/Low are now WarningHigh/WarningLow respectively.

IOptions now replaced with IOptionsMonitor.

Pipelines updated to only publish the .exe now.