### PR TITLE
Validates Nightscout Url when saving settings.

### DIFF
--- a/GlucoseTrayCore/GlucoseTraySettings.cs
+++ b/GlucoseTrayCore/GlucoseTraySettings.cs
@@ -21,7 +21,14 @@ namespace GlucoseTrayCore
         private string nightscoutUrl;
         public string NightscoutUrl
         {
-            get => nightscoutUrl; set { nightscoutUrl = value; OnPropertyChanged(nameof(NightscoutUrl)); }
+            get => nightscoutUrl; 
+            set 
+            { 
+                nightscoutUrl = value;
+                if (nightscoutUrl.EndsWith("/"))
+                    nightscoutUrl = nightscoutUrl.Remove(nightscoutUrl.Length - 1);
+                OnPropertyChanged(nameof(NightscoutUrl)); 
+            }
         }
 
         private DexcomServerLocation dexcomServer;

--- a/GlucoseTrayCore/Models/NightScoutStatus.cs
+++ b/GlucoseTrayCore/Models/NightScoutStatus.cs
@@ -1,0 +1,16 @@
+﻿namespace GlucoseTrayCore.Models
+{
+    /// <summary>
+    /// Class that maps to the JSON from NightScout status.
+    /// </summary>
+    /// <remarks>
+    /// Currently only maps the status value.
+    /// 
+    /// Would it be possible to read the units and alarm thresholds from nightscout?
+    /// </remarks>
+    internal class NightScoutStatus
+    {
+        public string status { get; set; }
+        
+    }
+}

--- a/GlucoseTrayCore/appsettings.json
+++ b/GlucoseTrayCore/appsettings.json
@@ -1,5 +1,5 @@
 {
   "appsettings": {
-    "Version": "11.1.2"
+    "Version": "11.1.3"
   }
 }


### PR DESCRIPTION
Fix for https://github.com/Delubear/GlucoseTray/issues/53 :  Fix - Handle Nightscout URLs ending with a / #53

Also validates the Nightscout URL and AccessToken when setting up.
