### PR TITLE
Fixes for long passwords on .Net6 and for Tomato app

### DIFF
--- a/GlucoseTray/Services/GlucoseFetchService.cs
+++ b/GlucoseTray/Services/GlucoseFetchService.cs
@@ -116,7 +116,9 @@ namespace GlucoseTray.Services
                     var fetchResult = new GlucoseResult
                     {
                         Source = FetchMethod.NightscoutApi,
-                        DateTimeUTC = DateTime.Parse(record.DateString).ToUniversalTime(),
+                        DateTimeUTC = !String.IsNullOrEmpty(record.DateString) ?
+                                        DateTime.Parse(record.DateString).ToUniversalTime() :
+                                        DateTimeOffset.FromUnixTimeMilliseconds(record.Date).UtcDateTime,
                         Trend = record.Direction.GetTrend()
                     };
                     CalculateValues(fetchResult, record.Sgv);

--- a/GlucoseTray/Services/StringEncryptionService.cs
+++ b/GlucoseTray/Services/StringEncryptionService.cs
@@ -48,7 +48,24 @@ namespace GlucoseTray.Services
             var memoryStream = new MemoryStream(cipherTextBytes);
             var cryptoStream = new CryptoStream(memoryStream, decryptor, CryptoStreamMode.Read);
             byte[] plainTextBytes = new byte[cipherTextBytes.Length];
-            int decryptedByteCount = cryptoStream.Read(plainTextBytes, 0, plainTextBytes.Length);
+
+            // int decryptedByteCount = cryptoStream.Read(plainTextBytes, 0, plainTextBytes.Length);
+
+            // Amended for Dotnet 6.0 and above which now longer guarentees that you will get all 
+            // the bytes you asked for in the first read, so we need to keep reading until the end.
+            int decryptedByteCount = 0;
+            byte[] tempBytes = new byte[cipherTextBytes.Length];
+            do
+            {
+                int bytesRead  = cryptoStream.Read(tempBytes, 0, tempBytes.Length);
+                if (bytesRead == 0)
+                    break;
+
+                Array.Copy(tempBytes, 0, plainTextBytes, decryptedByteCount, bytesRead);
+                decryptedByteCount += bytesRead;
+            }
+            while (true);
+
             memoryStream.Close();
             cryptoStream.Close();
             return Encoding.UTF8.GetString(plainTextBytes, 0, decryptedByteCount);

--- a/GlucoseTray/appsettings.json
+++ b/GlucoseTray/appsettings.json
@@ -1,5 +1,5 @@
 {
   "appsettings": {
-    "Version": "12.0.1"
+    "Version": "12.0.2"
   }
 }

--- a/GlucoseTray/appsettings.json
+++ b/GlucoseTray/appsettings.json
@@ -1,5 +1,5 @@
 {
   "appsettings": {
-    "Version": "12.0.0"
+    "Version": "12.0.1"
   }
 }


### PR DESCRIPTION
There has been a change to the .Net 6.0 runtime which breaks the decryption of passwords over 16 characters. This patch should fix that.

Also added a patch to workaround an issue where Nightscout could be missing the dateString field as occurs with data uploaded using the Tomato app.
